### PR TITLE
refactor: Convert types to public from the application layer

### DIFF
--- a/src/Application/Players/Accounts/AccountComponent.cs
+++ b/src/Application/Players/Accounts/AccountComponent.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Accounts;
 
-internal class AccountComponent : Component
+public class AccountComponent : Component
 {
     public PlayerInfo PlayerInfo { get; }
     public AccountStatus Status { get; }

--- a/src/Application/Players/Accounts/AccountStatus.cs
+++ b/src/Application/Players/Accounts/AccountStatus.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Accounts;
 
-internal enum AccountStatus
+public enum AccountStatus
 {
     LoggedIn,
     Registered

--- a/src/Application/Players/Accounts/RoleCollection.cs
+++ b/src/Application/Players/Accounts/RoleCollection.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Accounts;
 
-internal class RoleCollection
+public class RoleCollection
 {
     private RoleCollection() { }
     private static readonly RoleId[] s_roles = Enum.GetValues<RoleId>();

--- a/src/Application/Players/Ranks/IRank.cs
+++ b/src/Application/Players/Ranks/IRank.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Ranks;
 
-internal interface IRank
+public interface IRank
 {
     RankId Id { get; }
     string Name { get; }

--- a/src/Application/Players/Ranks/RankCollection.cs
+++ b/src/Application/Players/Ranks/RankCollection.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Ranks;
 
-internal class RankCollection
+public class RankCollection
 {
     private static readonly Rank[] s_ranks = 
     [

--- a/src/Application/Players/Ranks/RankSystem.cs
+++ b/src/Application/Players/Ranks/RankSystem.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Ranks;
 
-internal class RankSystem : ISystem
+public class RankSystem : ISystem
 {
     [PlayerCommand("ranks")]
     public void ShowRanks(Player player, IDialogService dialogService)

--- a/src/Application/Players/Weapons/GtaWeapons.cs
+++ b/src/Application/Players/Weapons/GtaWeapons.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Weapons;
 
-internal class GtaWeapons
+public class GtaWeapons
 {
     private static readonly GtaWeapon[] s_weapons =
     [

--- a/src/Application/Players/Weapons/IWeapon.cs
+++ b/src/Application/Players/Weapons/IWeapon.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Weapons;
 
-internal interface IWeapon
+public interface IWeapon
 {
     const int UnlimitedAmmo = 99999999;
     Weapon Id { get; }

--- a/src/Application/Players/Weapons/WeaponPack.cs
+++ b/src/Application/Players/Weapons/WeaponPack.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Weapons;
 
-internal class WeaponPack : IEnumerable<IWeapon>
+public class WeaponPack : IEnumerable<IWeapon>
 {
     private readonly List<IWeapon> _weapons =
     [

--- a/src/Application/Players/Weapons/WeaponSelectionComponent.cs
+++ b/src/Application/Players/Weapons/WeaponSelectionComponent.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Weapons;
 
-internal class WeaponSelectionComponent : Component
+public class WeaponSelectionComponent : Component
 {
     public WeaponPack SelectedWeapons { get; } = new();
 }

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Weapons;
 
-internal class WeaponSystem : ISystem
+public class WeaponSystem : ISystem
 {
     [Event]
     public void OnPlayerConnect(Player player)

--- a/src/Application/Teams/ClassSelectionComponent.cs
+++ b/src/Application/Teams/ClassSelectionComponent.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Teams;
 
-internal class ClassSelectionComponent : Component
+public class ClassSelectionComponent : Component
 {
     public bool IsInClassSelection { get; set; } = true;
 }


### PR DESCRIPTION
There is no benefit in keeping the types as “internal”. This modifier is usually most beneficial when working on open source libraries, in which case you do not want to expose internal library details.

This PR also avoids this error: https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0053