### PR TITLE
refactor: Initialize dialog object in constructor to reduce memory allocations

### DIFF
--- a/src/Application/Players/Ranks/RankSystem.cs
+++ b/src/Application/Players/Ranks/RankSystem.cs
@@ -2,23 +2,28 @@
 
 public class RankSystem : ISystem
 {
-    [PlayerCommand("ranks")]
-    public void ShowRanks(Player player, IDialogService dialogService)
+    private readonly TablistDialog _tablistDialog;
+    public RankSystem()
     {
-        var columnHeaders = new[] 
+        var columnHeaders = new[]
         {
             "Rank",
             "Total Required Kills"
         };
-        var dialog = new TablistDialog(
-            caption: "Ranks", 
-            button1: "Close", 
+        _tablistDialog = new TablistDialog(
+            caption: "Ranks",
+            button1: "Close",
             button2: null,
             columnHeaders);
+
         var ranks = RankCollection.GetAll();
         foreach (IRank rank in ranks)
-            dialog.Add(rank.Name, rank.RequiredKills.ToString());
+            _tablistDialog.Add(rank.Name, rank.RequiredKills.ToString());
+    }
 
-        dialogService.ShowAsync(player, dialog);
+    [PlayerCommand("ranks")]
+    public void ShowRanks(Player player, IDialogService dialogService)
+    {
+        dialogService.ShowAsync(player, _tablistDialog);
     }
 }

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -2,6 +2,15 @@
 
 public class WeaponSystem : ISystem
 {
+    private readonly ListDialog _weaponsDialog;
+    public WeaponSystem()
+    {
+        _weaponsDialog = new ListDialog("Weapons", "Select", "Close");
+        var weapons = GtaWeapons.GetAll();
+        foreach (IWeapon weapon in weapons)
+            _weaponsDialog.Add(weapon.Name);
+    }
+
     [Event]
     public void OnPlayerConnect(Player player)
     {
@@ -27,12 +36,7 @@ public class WeaponSystem : ISystem
     {
         var weaponSelection = player.GetComponent<WeaponSelectionComponent>();
         WeaponPack selectedWeapons = weaponSelection.SelectedWeapons;
-        var dialog = new ListDialog("Weapons", "Select", "Close");
-        var weapons = GtaWeapons.GetAll();
-        foreach (IWeapon weapon in weapons)
-            dialog.Add(weapon.Name);
-
-        ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
+        ListDialogResponse response = await dialogService.ShowAsync(player, _weaponsDialog);
         if (response.Response == DialogResponse.RightButtonOrCancel)
             return;
 


### PR DESCRIPTION
The rank and weapon dialogs always have the same items, so they can be created from the constructor.