### PR TITLE
BREAKING CHANGE: Use ICombo interface instead of IBenefit

### DIFF
--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -295,7 +295,7 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {PlayerName} redeemed their points for the benefit: {BenefitName}.
+        ///   Looks up a localized string similar to {PlayerName} redeemed their points for the combo: {ComboName}.
         /// </summary>
         internal static string RedeemedPoints {
             get {

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -196,7 +196,7 @@
     <value>You have gained +100 points, +100 armour, and +100 health</value>
   </data>
   <data name="RedeemedPoints" xml:space="preserve">
-    <value>{PlayerName} redeemed their points for the benefit: {BenefitName}</value>
+    <value>{PlayerName} redeemed their points for the combo: {ComboName}</value>
   </data>
   <data name="SpawnLocationFailure" xml:space="preserve">
     <value>A spawn location can only be obtained for the alpha or beta team</value>

--- a/src/Application/Players/Combos/ComboSystem.cs
+++ b/src/Application/Players/Combos/ComboSystem.cs
@@ -5,16 +5,16 @@ public class ComboSystem : ISystem
     private readonly IDialogService _dialogService;
     private readonly TablistDialog _tablistDialog;
     private readonly IWorldService _worldService;
-    private readonly IEnumerable<IBenefit> _benefits;
+    private readonly IEnumerable<ICombo> _combos;
 
     public ComboSystem(
         IDialogService dialogService,
         IWorldService worldService,
-        IEnumerable<IBenefit> benefits)
+        IEnumerable<ICombo> combos)
     {
         _dialogService = dialogService;
         _worldService = worldService;
-        _benefits = benefits;
+        _combos = combos;
         var columnHeaders = new[]
         {
             "Combo",
@@ -26,8 +26,8 @@ public class ComboSystem : ISystem
             button2: "Close",
             columnHeaders);
 
-        foreach (IBenefit benefit in benefits)
-            _tablistDialog.Add(benefit.Name, benefit.RequiredPoints.ToString());
+        foreach (ICombo combo in combos)
+            _tablistDialog.Add(combo.Name, combo.RequiredPoints.ToString());
     }
 
     [PlayerCommand("combos")]
@@ -38,9 +38,9 @@ public class ComboSystem : ISystem
             return;
 
         string selectedItemName = response.Item.Columns[0];
-        IBenefit selectedBenefit = _benefits.First(benefit => benefit.Name == selectedItemName);
+        ICombo selectedCombo = _combos.First(combo => combo.Name == selectedItemName);
         PlayerStatsPerRound playerStats = player.GetInfo().StatsPerRound;
-        if(playerStats.HasInsufficientPoints(selectedBenefit.RequiredPoints))
+        if(playerStats.HasInsufficientPoints(selectedCombo.RequiredPoints))
         {
             player.SendClientMessage(Color.Red, Messages.InsufficientPoints);
             ShowCombos(player);
@@ -50,10 +50,10 @@ public class ComboSystem : ISystem
         var message = Smart.Format(Messages.RedeemedPoints, new 
         { 
             PlayerName  = player.Name,
-            BenefitName = selectedBenefit.Name
+            ComboName = selectedCombo.Name
         });
         _worldService.SendClientMessage(Color.Yellow, message);
-        selectedBenefit.Give(player);
+        selectedCombo.Give(player);
         ShowCombos(player);
     }
 }

--- a/src/Application/Players/Combos/IBenefit.cs
+++ b/src/Application/Players/Combos/IBenefit.cs
@@ -1,8 +1,0 @@
-﻿namespace CTF.Application.Players.Combos;
-
-public interface IBenefit
-{
-    string Name { get; }
-    int RequiredPoints { get; }
-    void Give(Player player);
-}

--- a/src/Application/Players/Combos/ICombo.cs
+++ b/src/Application/Players/Combos/ICombo.cs
@@ -1,0 +1,12 @@
+﻿namespace CTF.Application.Players.Combos;
+
+/// <summary>
+/// Represents a combination of different advantages, such as health, armour, and weapons, 
+/// that a player can use to gain an advantage in the game.
+/// </summary>
+public interface ICombo
+{
+    string Name { get; }
+    int RequiredPoints { get; }
+    void Give(Player player);
+}

--- a/src/Application/Players/Combos/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Combos/ServiceCollectionExtensions.cs
@@ -5,11 +5,11 @@ public static class ComboServicesExtensions
     public static IServiceCollection AddComboServices(this IServiceCollection services)
     {
         services
-            .AddSingleton<IBenefit, HealthArmour>()
-            .AddSingleton<IBenefit, GrenadesArmour>()
-            .AddSingleton<IBenefit, MolotovArmour>()
-            .AddSingleton<IBenefit, SatchelChargesArmour>()
-            .AddSingleton<IBenefit, TearGasHealth>();
+            .AddSingleton<ICombo, HealthArmour>()
+            .AddSingleton<ICombo, GrenadesArmour>()
+            .AddSingleton<ICombo, MolotovArmour>()
+            .AddSingleton<ICombo, SatchelChargesArmour>()
+            .AddSingleton<ICombo, TearGasHealth>();
 
         return services;
     }

--- a/src/Application/Players/Combos/Services/GrenadesArmour.cs
+++ b/src/Application/Players/Combos/Services/GrenadesArmour.cs
@@ -1,14 +1,14 @@
-﻿namespace CTF.Application.Players.Combos.Benefits;
+﻿namespace CTF.Application.Players.Combos.Services;
 
-public class MolotovArmour : IBenefit
+public class GrenadesArmour : ICombo
 {
-    public string Name => "2 Molotov cocktail and 20 Armour";
+    public string Name => "2 Grenades and 20 Armour";
     public int RequiredPoints => 25;
 
     public void Give(Player player)
     {
         PlayerInfo playerInfo = player.GetInfo();
-        player.GiveWeapon(Weapon.Moltov, ammo: 2);
+        player.GiveWeapon(Weapon.Grenade, ammo: 2);
         player.AddArmour(20);
         playerInfo.StatsPerRound.SubtractPoints(-25);
     }

--- a/src/Application/Players/Combos/Services/HealthArmour.cs
+++ b/src/Application/Players/Combos/Services/HealthArmour.cs
@@ -1,6 +1,6 @@
-﻿namespace CTF.Application.Players.Combos.Benefits;
+﻿namespace CTF.Application.Players.Combos.Services;
 
-public class HealthArmour : IBenefit
+public class HealthArmour : ICombo
 {
     public string Name => "100 Health, 100 Armour and FlameThrower";
     public int RequiredPoints => 100;

--- a/src/Application/Players/Combos/Services/MolotovArmour.cs
+++ b/src/Application/Players/Combos/Services/MolotovArmour.cs
@@ -1,14 +1,14 @@
-﻿namespace CTF.Application.Players.Combos.Benefits;
+﻿namespace CTF.Application.Players.Combos.Services;
 
-public class GrenadesArmour : IBenefit
+public class MolotovArmour : ICombo
 {
-    public string Name => "2 Grenades and 20 Armour";
+    public string Name => "2 Molotov cocktail and 20 Armour";
     public int RequiredPoints => 25;
 
     public void Give(Player player)
     {
         PlayerInfo playerInfo = player.GetInfo();
-        player.GiveWeapon(Weapon.Grenade, ammo: 2);
+        player.GiveWeapon(Weapon.Moltov, ammo: 2);
         player.AddArmour(20);
         playerInfo.StatsPerRound.SubtractPoints(-25);
     }

--- a/src/Application/Players/Combos/Services/SatchelChargesArmour.cs
+++ b/src/Application/Players/Combos/Services/SatchelChargesArmour.cs
@@ -1,6 +1,6 @@
-﻿namespace CTF.Application.Players.Combos.Benefits;
+﻿namespace CTF.Application.Players.Combos.Services;
 
-public class SatchelChargesArmour : IBenefit
+public class SatchelChargesArmour : ICombo
 {
     public string Name => "4 Satchel charges and 30 Armour";
     public int RequiredPoints => 40;

--- a/src/Application/Players/Combos/Services/TearGasHealth.cs
+++ b/src/Application/Players/Combos/Services/TearGasHealth.cs
@@ -1,6 +1,6 @@
-﻿namespace CTF.Application.Players.Combos.Benefits;
+﻿namespace CTF.Application.Players.Combos.Services;
 
-public class TearGasHealth : IBenefit
+public class TearGasHealth : ICombo
 {
     public string Name => "20 Tear gas and 30 Health";
     public int RequiredPoints => 20;

--- a/src/Application/Usings.cs
+++ b/src/Application/Usings.cs
@@ -22,7 +22,7 @@ global using CTF.Application.Common.Extensions;
 global using CTF.Application.Players.Accounts;
 global using CTF.Application.Players.Ranks;
 global using CTF.Application.Players.Combos;
-global using CTF.Application.Players.Combos.Benefits;
+global using CTF.Application.Players.Combos.Services;
 global using CTF.Application.Players.Extensions;
 global using CTF.Application.Teams;
 global using CTF.Application.Teams.Flags;


### PR DESCRIPTION
This change was introduced because `ICombo` is that the represents the set of benefits that a player can obtain. `IBenefit` is not a good name, because it represents a single benefit and what we really want is to represent a set of benefits (a combo).

`ICombo`: Represents a combination of different advantages, such as health, armour, and weapons, that a player can use to gain an advantage in the game.