### PR TITLE
fix: Set new ammo to FlameThrower

### DIFF
--- a/src/Application/Players/Combos/Services/FlamethrowerVitality.cs
+++ b/src/Application/Players/Combos/Services/FlamethrowerVitality.cs
@@ -10,7 +10,9 @@ public class FlamethrowerVitality : ICombo
         PlayerInfo playerInfo = player.GetInfo();
         player.Health = 100;
         player.Armour = 100;
-        player.GiveWeapon(Weapon.FlameThrower, ammo: 500);
+        // 5500 (shows in game as 500-50).
+        const int ammo = 5500;
+        player.GiveWeapon(Weapon.FlameThrower, ammo);
         playerInfo.StatsPerRound.ResetPoints();
     }
 }


### PR DESCRIPTION
If the ammo is set to 500, it shows as 50.