### PR TITLE
BREAKING CHANGE: Rename class to PlayerDeathSystem

### DIFF
--- a/src/Application/Players/PlayerDeathSystem.cs
+++ b/src/Application/Players/PlayerDeathSystem.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players;
 
-public class PlayerSystem(
+public class PlayerDeathSystem(
     IWorldService worldService,
     IPlayerRepository playerRepository,
     PlayerRankUpdater playerRankUpdater,


### PR DESCRIPTION
“PlayerSystem” is a generic name, so it has been changed to "PlayerDeathSystem" to clarify its responsibility.