### PR TITLE
fix: Add/remove players when spawned or disconnected

### DIFF
--- a/src/Application/Players/PlayerSpawnSystem.cs
+++ b/src/Application/Players/PlayerSpawnSystem.cs
@@ -23,9 +23,24 @@ public class PlayerSpawnSystem(MapInfoService mapInfoService) : ISystem
         }
         player.GetComponent<ClassSelectionComponent>().IsInClassSelection = false;
         player.GameText("_", 1000, 4);
-        PlayerInfo playerInfo = accountComponent.PlayerInfo;
-        playerInfo.SetTeam((TeamId)player.Team);
+        accountComponent.PlayerInfo.SetTeam(selectedTeam.Id);
+        selectedTeam.Members.Add(player);
         return true;
+    }
+
+    [Event]
+    public void OnPlayerDisconnect(Player player, DisconnectReason reason)
+    {
+        var accountComponent = player.GetComponent<AccountComponent>();
+        bool isNotLoggedInOrRegistered = accountComponent is null;
+        if (isNotLoggedInOrRegistered)
+            return;
+
+        PlayerInfo playerInfo = accountComponent.PlayerInfo;
+        if (playerInfo.Team == Team.None)
+            return;
+
+        playerInfo.Team.Members.Remove(player);
     }
 
     [Event]


### PR DESCRIPTION
- When a player spawns for the first time, they must be added to the team they selected

- When a player disconnects, they must be removed from their current team