### PR TITLE
fix: Verify if the entered password is null

### DIFF
--- a/src/Application/Players/Accounts/Systems/AccountSystem.cs
+++ b/src/Application/Players/Accounts/Systems/AccountSystem.cs
@@ -43,7 +43,7 @@ public class AccountSystem(
             return;
         }
 
-        var enteredPassword = response.InputText;
+        var enteredPassword = response.InputText ?? string.Empty;
         CreatePlayerAccount(connectedPlayer, playerInfo, enteredPassword);
     }
 
@@ -76,7 +76,7 @@ public class AccountSystem(
             return;
         }
 
-        var enteredPassword = response.InputText;
+        var enteredPassword = response.InputText ?? string.Empty;
         bool isWrongPassword = !passwordHasher.Verify(enteredPassword, passwordHash: playerInfo.Password);
         if (isWrongPassword) 
         {

--- a/src/Application/Players/Accounts/Systems/ChangePasswordSystem.cs
+++ b/src/Application/Players/Accounts/Systems/ChangePasswordSystem.cs
@@ -20,7 +20,7 @@ public class ChangePasswordSystem(
         if (response.Response == DialogResponse.RightButtonOrCancel)
             return;
 
-        var enteredPassword = response.InputText;
+        var enteredPassword = response.InputText ?? string.Empty;
         ChangePassword(player, enteredPassword);
     }
 


### PR DESCRIPTION
Prevents potential exceptions when a player disconnects while the dialog is open.