### PR TITLE
fix: Prevent the player from returning to class selection after death

### DIFF
--- a/src/Application/Players/ClassSelectionSystem.cs
+++ b/src/Application/Players/ClassSelectionSystem.cs
@@ -11,6 +11,13 @@ public class ClassSelectionSystem : ISystem
     [Event]
     public void OnPlayerRequestClass(Player player, int classId)
     {
+        if(player.HasForcedClassSelection()) 
+        {
+            player.SetSpawnInfo(player.Team, player.Skin, player.Position, player.Angle);
+            player.Spawn();
+            return;
+        }
+
         player.Color = Color.White;
         player.Position = new Vector3(-1389.137451, 3314.043701, 20.493314);
         player.CameraPosition = new Vector3(-1399.776000, 3310.254150, 21.525623);

--- a/src/Application/Players/Extensions/ClassSelectionExtensions.cs
+++ b/src/Application/Players/Extensions/ClassSelectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace CTF.Application.Players.Extensions;
+
+public static class ClassSelectionExtensions
+{
+    public static bool IsInClassSelection(this Player player)
+        => player.GetComponent<ClassSelectionComponent>().IsInClassSelection;
+
+    public static bool IsNotInClassSelection(this Player player)
+        => !player.IsInClassSelection();
+
+    public static bool HasForcedClassSelection(this Player player)
+        => !player.IsInClassSelection();
+
+    public static void SetInClassSelection(this Player player)
+        => player.GetComponent<ClassSelectionComponent>().IsInClassSelection = true;
+
+    public static void RemoveFromClassSelection(this Player player)
+        => player.GetComponent<ClassSelectionComponent>().IsInClassSelection = false;
+}

--- a/src/Application/Players/PlayerSpawnSystem.cs
+++ b/src/Application/Players/PlayerSpawnSystem.cs
@@ -21,7 +21,7 @@ public class PlayerSpawnSystem(MapInfoService mapInfoService) : ISystem
             player.GameText(gameText, 999999999, 3);
             return false;
         }
-        player.GetComponent<ClassSelectionComponent>().IsInClassSelection = false;
+        player.RemoveFromClassSelection();
         player.GameText("_", 1000, 4);
         accountComponent.PlayerInfo.SetTeam(selectedTeam.Id);
         selectedTeam.Members.Add(player);


### PR DESCRIPTION
Do not allow the player to return to class selection after death. This prevents a bug where the team counter can be affected. For example, if Player A is from Team Alpha and returns to class selection to choose Team Alpha again, it would result in duplicate team members, which is incorrect. If a player wants to change teams, they should use the provided command instead.