### PR TITLE
BREAKING CHANGE: Rename method to EnableClassSelection

### DIFF
--- a/src/Application/Players/Extensions/ClassSelectionExtensions.cs
+++ b/src/Application/Players/Extensions/ClassSelectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ClassSelectionExtensions
     public static bool HasForcedClassSelectionAfterDeath(this Player player)
         => !player.IsInClassSelection();
 
-    public static void SetInClassSelection(this Player player)
+    public static void EnableClassSelection(this Player player)
         => player.GetComponent<ClassSelectionComponent>().IsInClassSelection = true;
 
     public static void RemoveFromClassSelection(this Player player)


### PR DESCRIPTION
“SetInClassSelection” is used when placing a player in the class selection, but this method doesn't actually do that, instead it just changes the state to true.