### PR TITLE
BREAKING CHANGE: Rename method to DisableClassSelection

### DIFF
--- a/src/Application/Players/Extensions/ClassSelectionExtensions.cs
+++ b/src/Application/Players/Extensions/ClassSelectionExtensions.cs
@@ -14,6 +14,6 @@ public static class ClassSelectionExtensions
     public static void EnableClassSelection(this Player player)
         => player.GetComponent<ClassSelectionComponent>().IsInClassSelection = true;
 
-    public static void RemoveFromClassSelection(this Player player)
+    public static void DisableClassSelection(this Player player)
         => player.GetComponent<ClassSelectionComponent>().IsInClassSelection = false;
 }

--- a/src/Application/Players/PlayerSpawnSystem.cs
+++ b/src/Application/Players/PlayerSpawnSystem.cs
@@ -21,7 +21,7 @@ public class PlayerSpawnSystem(MapInfoService mapInfoService) : ISystem
             player.GameText(gameText, 999999999, 3);
             return false;
         }
-        player.RemoveFromClassSelection();
+        player.DisableClassSelection();
         player.GameText("_", 1000, 4);
         accountComponent.PlayerInfo.SetTeam(selectedTeam.Id);
         selectedTeam.Members.Add(player);


### PR DESCRIPTION
“RemoveFromClassSelection” is used when removing a player from the class selection, but this method doesn't actually do that, instead it just changes the state to false.