### PR TITLE
Update team icons to Colored Square/Triangle

### DIFF
--- a/src/Application/Teams/Flags/FlagIcon.cs
+++ b/src/Application/Teams/Flags/FlagIcon.cs
@@ -3,6 +3,6 @@
 public enum FlagIcon
 {
     None = 1,
-    Red = 20,
-    Blue = 30
+    Red = 0,
+    Blue = Red
 }

--- a/src/Application/Teams/Team.cs
+++ b/src/Application/Teams/Team.cs
@@ -15,7 +15,7 @@ public class Team
             Name       = "Alpha",
             ColorName  = "Red",
             GameText   = "~r~",
-            ColorHex   = new Color(255, 32, 64),
+            ColorHex   = new Color(255, 32, 64, 00),
             Sounds     = TeamSounds.Alpha,
             Flag       = new Flag
             {
@@ -33,7 +33,7 @@ public class Team
             Name       = "Beta",
             ColorName  = "Blue",
             GameText   = "~b~",
-            ColorHex   = new Color(0, 136, 255),
+            ColorHex   = new Color(0, 136, 255, 00),
             Sounds     = TeamSounds.Beta,
             Flag       = new Flag
             {
@@ -53,7 +53,7 @@ public class Team
             Name       = "NoTeam",
             ColorName  = "White",
             GameText   = "~w~",
-            ColorHex   = Color.White,
+            ColorHex   = new Color(255, 255, 255, 00),
             Sounds     = TeamSounds.None,
             Flag       = new Flag
             {


### PR DESCRIPTION
The ID 20 and 30 icons are not shown in interiors as in RC Battlefield or Crack Factory, for that reason it was decided to use the ID 0 icon (Colored Square/Triangle) for both teams (Alpha and Beta), because it is available for all interiors.

**Note:** *The color representing each player will not be shown on the radar map.*

See https://www.open.mp/docs/scripting/resources/mapicons