### PR TITLE
fix: Fix bug with outdated map information due to singleton registration

### DIFF
--- a/src/Application/Players/PlayerSpawnSystem.cs
+++ b/src/Application/Players/PlayerSpawnSystem.cs
@@ -2,16 +2,15 @@
 
 public class PlayerSpawnSystem(MapInfoService mapInfoService) : ISystem
 {
-    private readonly CurrentMap _currentMap = mapInfoService.Read();
-
     [Event]
     public void OnPlayerSpawn(Player player)
     {
+        CurrentMap currentMap = mapInfoService.Read();
         PlayerInfo playerInfo = player.GetInfo();
-        SpawnLocation spawnLocation = _currentMap.GetRandomSpawnLocation(playerInfo.Team.Id);
+        SpawnLocation spawnLocation = currentMap.GetRandomSpawnLocation(playerInfo.Team.Id);
         player.Position = spawnLocation.Position;
         player.Angle = spawnLocation.Angle;
-        player.Interior = _currentMap.Interior;
+        player.Interior = currentMap.Interior;
         player.Color = playerInfo.Team.ColorHex;
         player.Team = (int)playerInfo.Team.Id;
         if (playerInfo.HasSkin())

--- a/src/Application/Teams/Services/TeamIconService.cs
+++ b/src/Application/Teams/Services/TeamIconService.cs
@@ -2,15 +2,15 @@
 
 public class TeamIconService
 {
-    private readonly CurrentMap _currentMap;
+    private readonly MapInfoService _mapInfoService;
     private readonly IStreamerService _streamerService;
     private DynamicMapIcon _redMapIcon;
     private DynamicMapIcon _blueMapIcon;
 
     public TeamIconService(MapInfoService mapInfoService, IStreamerService streamerService)
     {
+        _mapInfoService = mapInfoService;
         _streamerService = streamerService;
-        _currentMap = mapInfoService.Read();
         CreateFromBasePosition(Team.Alpha);
         CreateFromBasePosition(Team.Beta);
     }
@@ -18,19 +18,21 @@ public class TeamIconService
     public void CreateFromBasePosition(Team team)
     {
         ArgumentNullException.ThrowIfNull(team);
-        if(team.Id == TeamId.Alpha)
+        CurrentMap currentMap = _mapInfoService.Read();
+        if (team.Id == TeamId.Alpha)
         {
-            CreateFromVector3(team, _currentMap.FlagLocations.Red);
+            CreateFromVector3(team, currentMap.FlagLocations.Red);
         }
         else if(team.Id == TeamId.Beta) 
         {
-            CreateFromVector3(team, _currentMap.FlagLocations.Blue);
+            CreateFromVector3(team, currentMap.FlagLocations.Blue);
         }
     }
 
     public void CreateFromVector3(Team team, Vector3 position) 
     {
         ArgumentNullException.ThrowIfNull(team);
+        CurrentMap currentMap = _mapInfoService.Read();
         Destroy(team);
         if (team.Id == TeamId.Alpha)
         {
@@ -38,7 +40,7 @@ public class TeamIconService
                 position: position,
                 mapIcon: (MapIcon)Team.Alpha.Flag.Icon,
                 streamDistance: 5000f,
-                interior: _currentMap.Interior,
+                interior: currentMap.Interior,
                 color: Team.Alpha.Flag.ColorHex
             );
         }
@@ -48,7 +50,7 @@ public class TeamIconService
                 position: position,
                 mapIcon: (MapIcon)Team.Beta.Flag.Icon,
                 streamDistance: 5000f,
-                interior: _currentMap.Interior,
+                interior: currentMap.Interior,
                 color: Team.Beta.Flag.ColorHex
             );
         }

--- a/src/Application/Teams/Services/TeamPickupService.cs
+++ b/src/Application/Teams/Services/TeamPickupService.cs
@@ -2,7 +2,7 @@
 
 public class TeamPickupService
 {
-    private readonly CurrentMap _currentMap;
+    private readonly MapInfoService _mapInfoService;
     private readonly IWorldService _worldService;
     private Pickup _redFlagPickup;
     private Pickup _blueFlagPickup;
@@ -11,8 +11,8 @@ public class TeamPickupService
 
     public TeamPickupService(MapInfoService mapInfoService, IWorldService worldService)
     {
+        _mapInfoService = mapInfoService;
         _worldService = worldService;
-        _currentMap = mapInfoService.Read();
         CreateFlagFromBasePosition(Team.Alpha);
         CreateFlagFromBasePosition(Team.Beta);
     }
@@ -20,13 +20,14 @@ public class TeamPickupService
     public void CreateFlagFromBasePosition(Team team)
     {
         ArgumentNullException.ThrowIfNull(team);
+        CurrentMap currentMap = _mapInfoService.Read();
         if (team.Id == TeamId.Alpha)
         {
-            CreateFlagFromVector3(team, _currentMap.FlagLocations.Red);
+            CreateFlagFromVector3(team, currentMap.FlagLocations.Red);
         }
         else if(team.Id == TeamId.Beta) 
         {
-            CreateFlagFromVector3(team, _currentMap.FlagLocations.Blue);
+            CreateFlagFromVector3(team, currentMap.FlagLocations.Blue);
         }
     }
 
@@ -76,13 +77,14 @@ public class TeamPickupService
     public void CreatePickupWithInfo(Team team)
     {
         ArgumentNullException.ThrowIfNull(team);
+        CurrentMap currentMap = _mapInfoService.Read();
         DestroyPickupWithInfo(team);
         if (team.Id == TeamId.Alpha)
         {
             _alphaPickupInfo = _worldService.CreatePickup(
                 model: 1239,
                 type: PickupType.ScriptedActionsOnlyEveryFewSeconds,
-                position: _currentMap.FlagLocations.Red
+                position: currentMap.FlagLocations.Red
             );
         }
         else if(team.Id == TeamId.Beta)
@@ -90,7 +92,7 @@ public class TeamPickupService
             _betaPickupInfo = _worldService.CreatePickup(
                 model: 1239,
                 type: PickupType.ScriptedActionsOnlyEveryFewSeconds,
-                position: _currentMap.FlagLocations.Blue
+                position: currentMap.FlagLocations.Blue
             );
         }
     }


### PR DESCRIPTION
The map information was being retrieved in the constructor of a singleton system, which meant it was only updated once during initialization. As a result, changes to the map were not reflected, causing the system to use outdated map information.

This PR addresses the issue by modifying the way map information is retrieved, ensuring it is always up-to-date.