### PR TITLE
refactor: Create 'ServiceCollectionExtensions' for Players and Maps modules

### DIFF
--- a/src/Application/Maps/ServiceCollectionExtensions.cs
+++ b/src/Application/Maps/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace CTF.Application.Maps;
+
+public static class MapServicesExtensions
+{
+    public static IServiceCollection AddMapServices(this IServiceCollection services)
+    {
+        services
+            .AddSingleton<MapInfoService>()
+            .AddSingleton<MapTextDrawRenderer>();
+
+        return services;
+    }
+}

--- a/src/Application/Players/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace CTF.Application.Players;
+
+public static class PlayerServicesExtensions
+{
+    public static IServiceCollection AddPlayerServices(this IServiceCollection services)
+    {
+        services
+            .AddSingleton<PlayerRankUpdater>()
+            .AddSingleton<KillingSpreeUpdater>()
+            .AddSingleton<PlayerStatsRenderer>()
+            .AddComboServices();
+
+        return services;
+    }
+}

--- a/src/Application/ServiceCollectionExtensions.cs
+++ b/src/Application/ServiceCollectionExtensions.cs
@@ -6,12 +6,8 @@ public static class ApplicationServicesExtensions
     {
         services
             .AddSingleton<ServerTimeService>()
-            .AddSingleton<MapInfoService>()
-            .AddSingleton<PlayerRankUpdater>()
-            .AddSingleton<KillingSpreeUpdater>()
-            .AddSingleton<PlayerStatsRenderer>()
-            .AddSingleton<MapTextDrawRenderer>()
-            .AddComboServices()
+            .AddPlayerServices()
+            .AddMapServices()
             .AddTeamServices();
 
         return services;


### PR DESCRIPTION
Each module is now responsible for adding its own services to the service collection through a dedicated ServiceCollectionExtensions.cs file, improving modularity and organization.