### PR TITLE
BREAKING CHANGE: Inject an argument of type TimeLeft instead of a string

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -67,7 +67,7 @@ public class MapRotationService
         }
 
         _timeLeft.Decrease();
-        _mapTextDrawRenderer.UpdateTimeLeft(text: _timeLeft.TextDraw);
+        _mapTextDrawRenderer.UpdateTimeLeft(_timeLeft);
     }
 
     private void OnLoadingMap()

--- a/src/Application/Maps/Services/MapTextDrawRenderer.cs
+++ b/src/Application/Maps/Services/MapTextDrawRenderer.cs
@@ -35,9 +35,9 @@ public class MapTextDrawRenderer
         _mapName.Text = currentMap.GetMapNameAsText();
     }
 
-    public void UpdateTimeLeft(string text)
+    public void UpdateTimeLeft(TimeLeft timeLeft)
     {
-        _timeLeft.Text = text;
+        _timeLeft.Text = timeLeft.TextDraw;
     }
 
     private void Initialize()


### PR DESCRIPTION
This change is implemented to ensure that the "UpdateTimeLeft" method only updates the text in a fixed format. Previously, a string could be passed in any format, which could lead to inconsistencies or errors in how the time was displayed.

By using the "TimeLeft" class, we ensure that the text format is always **00:00**, as required for correct time display. 
The "TimeLeft" class enforces this format, preventing any incorrect formats from being used and improving the consistency and reliability of the time presentation.