### PR TITLE
BREAKING CHANGE: Modify UpdateMapName to accept a CurrentMap type argument

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -129,6 +129,6 @@ public class MapRotationService
         _teamTextDrawRenderer.UpdateTeamMembers(Team.Beta);
         _worldService.SetWeather(currentMap.Weather);
         _serverService.SetWorldTime(currentMap.WorldTime);
-        _mapTextDrawRenderer.UpdateMapName();
+        _mapTextDrawRenderer.UpdateMapName(currentMap);
     }
 }

--- a/src/Application/Maps/Services/MapTextDrawRenderer.cs
+++ b/src/Application/Maps/Services/MapTextDrawRenderer.cs
@@ -3,15 +3,13 @@
 public class MapTextDrawRenderer
 {
     private readonly IWorldService _worldService;
-    private readonly MapInfoService _mapInfoService;
     private TextDraw _mapName;
     private TextDraw _timer;
     private TextDraw _timeLeft;
 
-    public MapTextDrawRenderer(IWorldService worldService, MapInfoService mapInfoService)
+    public MapTextDrawRenderer(IWorldService worldService)
     {
         _worldService = worldService;
-        _mapInfoService = mapInfoService;
         Initialize();
     }
 
@@ -29,9 +27,8 @@ public class MapTextDrawRenderer
         _timeLeft.Hide(player);
     }
 
-    public void UpdateMapName()
+    public void UpdateMapName(CurrentMap currentMap)
     {
-        CurrentMap currentMap = _mapInfoService.Read();
         _mapName.Text = currentMap.GetMapNameAsText();
     }
 

--- a/src/Application/Maps/Systems/SetDefaultMapSystem.cs
+++ b/src/Application/Maps/Systems/SetDefaultMapSystem.cs
@@ -20,7 +20,7 @@ public class SetDefaultMapSystem(
         CurrentMap currentMap = mapInfoService.Read();
         serverService.SendRconCommand($"mapname {currentMap.Name}");
         serverService.SendRconCommand($"loadfs {currentMap.Name}");
-        mapTextDrawRenderer.UpdateMapName();
+        mapTextDrawRenderer.UpdateMapName(currentMap);
 
         worldService.SetWeather(currentMap.Weather);
         serverService.SetWorldTime(currentMap.WorldTime);


### PR DESCRIPTION
The "UpdateMapName" method in the "MapTextDrawRenderer" class previously did not accept any arguments, which could be confusing as the Update prefix typically implies that the method should accept parameters for updating the related data.

To clarify the method's intent and improve usability, we have updated the "UpdateMapName" method to accept a CurrentMap type argument.