### PR TITLE
fix: Avoid exception when player disconnects while dialog is open

### DIFF
--- a/src/Application/Common/Extensions/DialogResponseExtensions.cs
+++ b/src/Application/Common/Extensions/DialogResponseExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace CTF.Application.Common.Extensions;
+
+public static class DialogResponseExtensions
+{
+    public static bool IsRightButtonOrDisconnected(this ListDialogResponse response)
+        => response.Response.IsRightButtonOrDisconnected();
+
+    public static bool IsRightButtonOrDisconnected(this TablistDialogResponse response)
+        => response.Response.IsRightButtonOrDisconnected();
+
+    public static bool IsRightButtonOrDisconnected(this InputDialogResponse response)
+        => response.Response.IsRightButtonOrDisconnected();
+
+    private static bool IsRightButtonOrDisconnected(this DialogResponse response)
+        => response == DialogResponse.RightButtonOrCancel ||
+           response == DialogResponse.Disconnected;
+}

--- a/src/Application/Players/Accounts/Systems/AccountSystem.cs
+++ b/src/Application/Players/Accounts/Systems/AccountSystem.cs
@@ -37,6 +37,9 @@ public class AccountSystem(
     private async void ShowSignupDialog(ConnectedPlayer connectedPlayer, PlayerInfo playerInfo)
     {
         InputDialogResponse response = await dialogService.ShowAsync(connectedPlayer, _signupDialog);
+        if (response.Response == DialogResponse.Disconnected)
+            return;
+
         if (response.Response == DialogResponse.RightButtonOrCancel)
         {
             ShowSignupDialog(connectedPlayer, playerInfo);
@@ -70,6 +73,9 @@ public class AccountSystem(
     private async void ShowLoginDialog(ConnectedPlayer connectedPlayer, PlayerInfo playerInfo)
     {
         InputDialogResponse response = await dialogService.ShowAsync(connectedPlayer, _loginDialog);
+        if (response.Response == DialogResponse.Disconnected)
+            return;
+
         if (response.Response == DialogResponse.RightButtonOrCancel)
         {
             ShowLoginDialog(connectedPlayer, playerInfo);

--- a/src/Application/Players/Accounts/Systems/ChangePasswordSystem.cs
+++ b/src/Application/Players/Accounts/Systems/ChangePasswordSystem.cs
@@ -17,7 +17,7 @@ public class ChangePasswordSystem(
     public async void ShowPasswordDialog(Player player)
     {
         InputDialogResponse response = await dialogService.ShowAsync(player, _passwordDialog);
-        if (response.Response == DialogResponse.RightButtonOrCancel)
+        if (response.IsRightButtonOrDisconnected())
             return;
 
         var enteredPassword = response.InputText ?? string.Empty;

--- a/src/Application/Players/Combos/ComboSystem.cs
+++ b/src/Application/Players/Combos/ComboSystem.cs
@@ -34,7 +34,7 @@ public class ComboSystem : ISystem
     public async void ShowCombos(Player player)
     {
         TablistDialogResponse response = await _dialogService.ShowAsync(player, _tablistDialog);
-        if (response.Response == DialogResponse.RightButtonOrCancel)
+        if (response.IsRightButtonOrDisconnected())
             return;
 
         string selectedItemName = response.Item.Columns[0];

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -37,7 +37,7 @@ public class WeaponSystem : ISystem
         var weaponSelection = player.GetComponent<WeaponSelectionComponent>();
         WeaponPack selectedWeapons = weaponSelection.SelectedWeapons;
         ListDialogResponse response = await dialogService.ShowAsync(player, _weaponsDialog);
-        if (response.Response == DialogResponse.RightButtonOrCancel)
+        if (response.IsRightButtonOrDisconnected())
             return;
 
         IWeapon weaponSelectedFromDialog = GtaWeapons.GetByIndex(response.ItemIndex).Value;
@@ -73,7 +73,7 @@ public class WeaponSystem : ISystem
             dialog.Add(weapon.Name);
 
         ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
-        if (response.Response == DialogResponse.RightButtonOrCancel)
+        if (response.IsRightButtonOrDisconnected())
             return;
 
         IWeapon weaponSelectedFromDialog = GtaWeapons.GetByName(response.Item.Text).Value;


### PR DESCRIPTION
This PR prevents a **NullReferenceException** when the player disconnects while the dialog is open:
```sh
[SampSharp:ERROR] Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
```