### PR TITLE
refactor!: Rename enum member to BasePosition for better reflect its purpose

### DIFF
--- a/src/Application/Teams/Flags/Events/OnFlagAtBasePosition.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagAtBasePosition.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class OnFlagAtBasePosition : IFlagEvent
 {
-    public FlagStatus FlagStatus => FlagStatus.InitialPosition;
+    public FlagStatus FlagStatus => FlagStatus.BasePosition;
 
     public void Handle(Team team, Player player)
     {

--- a/src/Application/Teams/Flags/FlagStatus.cs
+++ b/src/Application/Teams/Flags/FlagStatus.cs
@@ -3,9 +3,9 @@
 public enum FlagStatus
 {
     /// <summary>
-    /// Indicates that the flag is on its base.
+    /// Indicates that the flag is at the base position, where it is defended to prevent enemy capture.
     /// </summary>
-    InitialPosition,
+    BasePosition,
 
     /// <summary>
     /// Indicates that a player has captured the opposing team's flag from their base.

--- a/src/Application/Teams/Team.cs
+++ b/src/Application/Teams/Team.cs
@@ -125,7 +125,7 @@ public class Team
                 return FlagStatus.Brought;
             }
 
-            return FlagStatus.InitialPosition;
+            return FlagStatus.BasePosition;
         }
 
         if (flagPicker.Team == (int)Id)
@@ -143,7 +143,7 @@ public class Team
     {
         public NoTeam() { }
         public override string GetAvailabilityMessage(bool entireMessage = true) => string.Empty;
-        public override FlagStatus GetFlagStatus(Player flagPicker) => FlagStatus.InitialPosition;
+        public override FlagStatus GetFlagStatus(Player flagPicker) => FlagStatus.BasePosition;
         public override string GetMembersAsText() => string.Empty;
         public override string GetScoreAsText() => string.Empty;
         public override bool IsFull() => false;

--- a/tests/Application.Tests/Teams/GetFlagStatusTests.cs
+++ b/tests/Application.Tests/Teams/GetFlagStatusTests.cs
@@ -102,12 +102,12 @@ public class GetFlagStatusTests
     }
 
     [Test]
-    public void GetFlagStatus_WhenPlayerFromAlphaTeamAttemptsToCaptureTheFlagOfTheirTeamFromBase_ShouldReturnsInitialPositionStatus()
+    public void GetFlagStatus_WhenPlayerFromAlphaTeamAttemptsToCaptureTheFlagOfTheirTeamFromBase_ShouldReturnsBasePositionStatus()
     {
         // Arrange
         Team alphaTeam = Team.Alpha;
         var alphaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: alphaTeam.Id);
-        var expectedStatus = FlagStatus.InitialPosition;
+        var expectedStatus = FlagStatus.BasePosition;
 
         // Act
         FlagStatus actual = alphaTeam.GetFlagStatus(flagPicker: alphaTeamPlayer);
@@ -119,12 +119,12 @@ public class GetFlagStatusTests
     }
 
     [Test]
-    public void GetFlagStatus_WhenPlayerFromBetaTeamAttemptsToCaptureTheFlagOfTheirTeamFromBase_ShouldReturnsInitialPositionStatus()
+    public void GetFlagStatus_WhenPlayerFromBetaTeamAttemptsToCaptureTheFlagOfTheirTeamFromBase_ShouldReturnsBasePositionStatus()
     {
         // Arrange
         Team betaTeam = Team.Beta;
         var betaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: betaTeam.Id);
-        var expectedStatus = FlagStatus.InitialPosition;
+        var expectedStatus = FlagStatus.BasePosition;
 
         // Act
         FlagStatus actual = betaTeam.GetFlagStatus(flagPicker: betaTeamPlayer);


### PR DESCRIPTION
"BasePosition" is the concept used in the game mode, while "InitialPosition" is too general.