### PR TITLE
feat: Implement a timer to apply automatic flag return

### DIFF
--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -124,6 +124,15 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {ColorName} flag has automatically returned to its base position after {Seconds} seconds!.
+        /// </summary>
+        internal static string FlagAutoReturn {
+            get {
+                return ResourceManager.GetString("FlagAutoReturn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ~r~Welcome to Capture The Flag mode~n~~y~It is a game mode in which two teams (Alpha and Beta) compete to capture the other team&apos;s flag and bring it back to their own base to score a point.
         /// </summary>
         internal static string GameModeDescription {

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -138,6 +138,9 @@
   <data name="EmptyWeaponPackage" xml:space="preserve">
     <value>You have no items in your weapon package</value>
   </data>
+  <data name="FlagAutoReturn" xml:space="preserve">
+    <value>The {ColorName} flag has automatically returned to its base position after {Seconds} seconds!</value>
+  </data>
   <data name="GameModeDescription" xml:space="preserve">
     <value>~r~Welcome to Capture The Flag mode~n~~y~It is a game mode in which two teams (Alpha and Beta) compete to capture the other team's flag and bring it back to their own base to score a point</value>
   </data>

--- a/src/Application/Common/ServerSettings.cs
+++ b/src/Application/Common/ServerSettings.cs
@@ -8,4 +8,5 @@ public class ServerSettings
     public string MapName { get; init; } = string.Empty;
     public string WebUrl { get; init; } = string.Empty;
     public string IntroAudioUrl { get; init; } = string.Empty;
+    public int FlagAutoReturnTime { get; init; } = 120;
 }

--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -11,6 +11,7 @@ public class MapRotationService
     private readonly TeamPickupService _teamPickupService;
     private readonly TeamTextDrawRenderer _teamTextDrawRenderer;
     private readonly PlayerStatsRenderer _playerStatsRenderer;
+    private readonly FlagAutoReturnTimer _flagAutoReturnTimer;
     private readonly TimeLeft _timeLeft;
     private readonly LoadTime _loadTime;
     private TimerReference _timerReference;
@@ -27,7 +28,8 @@ public class MapRotationService
         TeamIconService teamIconService,
         TeamPickupService teamPickupService,
         TeamTextDrawRenderer teamTextDrawRenderer,
-        PlayerStatsRenderer playerStatsRenderer)
+        PlayerStatsRenderer playerStatsRenderer,
+        FlagAutoReturnTimer flagAutoReturnTimer)
     {
         _serverService = serverService;
         _worldService = worldService;
@@ -38,6 +40,7 @@ public class MapRotationService
         _teamPickupService = teamPickupService;
         _teamTextDrawRenderer = teamTextDrawRenderer;
         _playerStatsRenderer = playerStatsRenderer;
+        _flagAutoReturnTimer = flagAutoReturnTimer;
         _timeLeft = new TimeLeft();
         _loadTime = new LoadTime(OnLoadingMap, OnLoadedMap);
         _isMapLoading = false;
@@ -112,6 +115,8 @@ public class MapRotationService
         _teamIconService.DestroyAll();
         _teamIconService.CreateFromBasePosition(Team.Alpha);
         _teamIconService.CreateFromBasePosition(Team.Beta);
+        _flagAutoReturnTimer.Stop(Team.Alpha);
+        _flagAutoReturnTimer.Stop(Team.Beta);
         _serverService.SendRconCommand($"loadfs {nextMap.Name}");
         _serverService.SendRconCommand($"mapname {nextMap.Name}");
     }

--- a/src/Application/Teams/Flags/Events/OnFlagDropped.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagDropped.cs
@@ -7,7 +7,8 @@ public class OnFlagDropped(
     IPlayerRepository playerRepository,
     IWorldService worldService,
     TeamPickupService teamPickupService,
-    TeamSoundsService teamSoundsService) : IFlagEvent
+    TeamSoundsService teamSoundsService,
+    FlagAutoReturnTimer flagAutoReturnTimer) : IFlagEvent
 {
     public FlagStatus FlagStatus => FlagStatus.Dropped;
 
@@ -15,6 +16,7 @@ public class OnFlagDropped(
     {
         teamPickupService.CreateFlagFromVector3(team, player.Position);
         teamSoundsService.PlayFlagDroppedSound(team);
+        flagAutoReturnTimer.Start(team);
         team.Flag.RemoveCarrier();
         var message = Smart.Format(Messages.OnFlagDropped, new
         {

--- a/src/Application/Teams/Flags/Events/OnFlagReturned.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagReturned.cs
@@ -8,7 +8,8 @@ public class OnFlagReturned(
     IWorldService worldService,
     TeamPickupService teamPickupService,
     TeamSoundsService teamSoundsService,
-    PlayerStatsRenderer playerStatsRenderer) : IFlagEvent
+    PlayerStatsRenderer playerStatsRenderer,
+    FlagAutoReturnTimer flagAutoReturnTimer) : IFlagEvent
 {
     public FlagStatus FlagStatus => FlagStatus.Returned;
 
@@ -17,6 +18,7 @@ public class OnFlagReturned(
         teamPickupService.CreateFlagFromBasePosition(team);
         teamPickupService.DestroyPickupWithInfo(team);
         teamSoundsService.PlayFlagReturnedSound(team);
+        flagAutoReturnTimer.Stop(team);
         var message = Smart.Format(Messages.OnFlagReturned, new
         {
             PlayerName = player.Name,

--- a/src/Application/Teams/Flags/Events/OnFlagTaken.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagTaken.cs
@@ -6,7 +6,8 @@
 public class OnFlagTaken(
     IWorldService worldService,
     TeamPickupService teamPickupService,
-    TeamSoundsService teamSoundsService) : IFlagEvent
+    TeamSoundsService teamSoundsService,
+    FlagAutoReturnTimer flagAutoReturnTimer) : IFlagEvent
 {
     public FlagStatus FlagStatus => FlagStatus.Taken;
 
@@ -14,6 +15,7 @@ public class OnFlagTaken(
     {
         teamPickupService.DestroyFlag(team);
         teamSoundsService.PlayFlagTakenSound(team);
+        flagAutoReturnTimer.Stop(team);
         var message = Smart.Format(Messages.OnFlagTaken, new
         {
             PlayerName = player.Name,

--- a/src/Application/Teams/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ public static class TeamServicesExtensions
             .AddSingleton<TeamIconService>()
             .AddSingleton<TeamSoundsService>()
             .AddSingleton<TeamTextDrawRenderer>()
+            .AddSingleton<FlagAutoReturnTimer>()
             .AddSingleton<ClassSelectionTextDrawRenderer>()
             .AddFlagServices();
 

--- a/src/Application/Teams/Services/FlagAutoReturnTimer.cs
+++ b/src/Application/Teams/Services/FlagAutoReturnTimer.cs
@@ -1,0 +1,56 @@
+﻿namespace CTF.Application.Teams.Services;
+
+public class FlagAutoReturnTimer(
+    ITimerService timerService,
+    IWorldService worldService,
+    TeamPickupService teamPickupService,
+    TeamSoundsService teamSoundsService,
+    ServerSettings serverSettings)
+{
+    private TimerReference _alphaTeamTimer;
+    private TimerReference _betaTeamTimer;
+
+    public void Start(Team team)
+    {
+        void OnComplete(IServiceProvider serviceProvider)
+        {
+            teamPickupService.CreateFlagFromBasePosition(team);
+            teamPickupService.DestroyPickupWithInfo(team);
+            teamSoundsService.PlayFlagReturnedSound(team);
+            team.IsFlagAtBasePosition = true;
+            var message = Smart.Format(Messages.FlagAutoReturn, new
+            {
+                Seconds = serverSettings.FlagAutoReturnTime,
+                team.ColorName
+            });
+            worldService.SendClientMessage(team.ColorHex, message);
+            worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", 5000, 3);
+            Stop(team);
+        }
+
+        if (team.Id == TeamId.Alpha)
+        {
+            TimeSpan interval = TimeSpan.FromSeconds(serverSettings.FlagAutoReturnTime);
+            _alphaTeamTimer ??= timerService.Start(OnComplete, interval);
+        }
+        else if (team.Id == TeamId.Beta)
+        {
+            TimeSpan interval = TimeSpan.FromSeconds(serverSettings.FlagAutoReturnTime);
+            _betaTeamTimer ??= timerService.Start(OnComplete, interval);
+        }
+    }
+
+    public void Stop(Team team) 
+    { 
+        if (team.Id == TeamId.Alpha && _alphaTeamTimer is not null) 
+        {
+            timerService.Stop(_alphaTeamTimer);
+            _alphaTeamTimer = default;
+        }
+        else if (team.Id == TeamId.Beta && _betaTeamTimer is not null)
+        {
+            timerService.Stop(_betaTeamTimer);
+            _betaTeamTimer = default;
+        }
+    }
+}


### PR DESCRIPTION
This timer starts when the player drops the flag on the ground. After 120 seconds, the flag will automatically return to its base position.