### PR TITLE
refactor: Ammo balancing and item adjustments

### DIFF
--- a/src/Application/Players/Combos/Services/FlamethrowerVitality.cs
+++ b/src/Application/Players/Combos/Services/FlamethrowerVitality.cs
@@ -10,8 +10,8 @@ public class FlamethrowerVitality : ICombo
         PlayerInfo playerInfo = player.GetInfo();
         player.Health = 100;
         player.Armour = 100;
-        // 5500 (shows in game as 500-50).
-        const int ammo = 5500;
+        // 1000 (shows in game as 50-50).
+        const int ammo = 1000;
         player.GiveWeapon(Weapon.FlameThrower, ammo);
         playerInfo.StatsPerRound.ResetPoints();
     }

--- a/src/Application/Players/Combos/Services/GrenadesVitality.cs
+++ b/src/Application/Players/Combos/Services/GrenadesVitality.cs
@@ -2,7 +2,7 @@
 
 public class GrenadesVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and 25 Grenades";
+    public string Name => "100 Health, 100 Armour and Grenades";
     public int RequiredPoints => 100;
 
     public void Give(Player player)
@@ -10,7 +10,7 @@ public class GrenadesVitality : ICombo
         PlayerInfo playerInfo = player.GetInfo();
         player.Health = 100;
         player.Armour = 100;
-        player.GiveWeapon(Weapon.Grenade, ammo: 25);
+        player.GiveWeapon(Weapon.Grenade, ammo: 6);
         playerInfo.StatsPerRound.ResetPoints();
     }
 }

--- a/src/Application/Players/Combos/Services/MolotovVitality.cs
+++ b/src/Application/Players/Combos/Services/MolotovVitality.cs
@@ -2,7 +2,7 @@
 
 public class MolotovVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and 25 Molotov cocktail";
+    public string Name => "100 Health, 100 Armour and Molotov cocktail";
     public int RequiredPoints => 100;
 
     public void Give(Player player)
@@ -10,7 +10,7 @@ public class MolotovVitality : ICombo
         PlayerInfo playerInfo = player.GetInfo();
         player.Health = 100;
         player.Armour = 100;
-        player.GiveWeapon(Weapon.Moltov, ammo: 25);
+        player.GiveWeapon(Weapon.Moltov, ammo: 6);
         playerInfo.StatsPerRound.ResetPoints();
     }
 }

--- a/src/Application/Players/Combos/Services/SatchelChargesVitality.cs
+++ b/src/Application/Players/Combos/Services/SatchelChargesVitality.cs
@@ -2,7 +2,7 @@
 
 public class SatchelChargesVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and 25 Satchel charges";
+    public string Name => "100 Health, 100 Armour and Satchel charges";
     public int RequiredPoints => 100;
 
     public void Give(Player player)
@@ -10,7 +10,7 @@ public class SatchelChargesVitality : ICombo
         PlayerInfo playerInfo = player.GetInfo();
         player.Health = 100;
         player.Armour = 100;
-        player.GiveWeapon(Weapon.SatchelCharge, ammo: 25);
+        player.GiveWeapon(Weapon.SatchelCharge, ammo: 6);
         player.GiveWeapon(Weapon.Detonator, ammo: 1);
         playerInfo.StatsPerRound.ResetPoints();
     }

--- a/src/Application/Players/Combos/Services/TearGasVitality.cs
+++ b/src/Application/Players/Combos/Services/TearGasVitality.cs
@@ -2,7 +2,7 @@
 
 public class TearGasVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and 50 Tear gas";
+    public string Name => "100 Health, 100 Armour and Tear gas";
     public int RequiredPoints => 100;
 
     public void Give(Player player)
@@ -10,7 +10,7 @@ public class TearGasVitality : ICombo
         PlayerInfo playerInfo = player.GetInfo();
         player.Health = 100;
         player.Armour = 100;
-        player.GiveWeapon(Weapon.Teargas, ammo: 50);
+        player.GiveWeapon(Weapon.Teargas, ammo: 15);
         playerInfo.StatsPerRound.ResetPoints();
     }
 }


### PR DESCRIPTION
### Changes
- Adjusted grenade, molotov, and satchel ammo to 6 units to encourage more strategic use.
- Set tear gas ammo to 15 units, allowing for area control without being overly aggressive.
- Defined flamethrower ammo as 50-50 (2 reloads) to balance its destructive power and promote tactical management.