### PR TITLE
refactor!: Add 'OnPlayerDeath' method to 'PlayerStatsSystem'

### DIFF
--- a/src/Application/Players/PlayerDeathSystem.cs
+++ b/src/Application/Players/PlayerDeathSystem.cs
@@ -1,11 +1,6 @@
 ﻿namespace CTF.Application.Players;
 
-public class PlayerDeathSystem(
-    IWorldService worldService,
-    IPlayerRepository playerRepository,
-    PlayerRankUpdater playerRankUpdater,
-    KillingSpreeUpdater killingSpreeUpdater,
-    PlayerStatsRenderer playerStatsRenderer) : ISystem
+public class PlayerDeathSystem(IWorldService worldService) : ISystem
 {
     [Event]
     public void OnPlayerConnect(Player player)
@@ -23,22 +18,5 @@ public class PlayerDeathSystem(
     public void OnPlayerDeath(Player deadPlayer, Player killer, Weapon reason)
     {
         worldService.SendDeathMessage(killer, deadPlayer, reason);
-        PlayerInfo deadPlayerInfo = deadPlayer.GetInfo();
-        deadPlayerInfo.StatsPerRound.AddDeaths();
-        deadPlayerInfo.StatsPerRound.ResetKillingSpree();
-        deadPlayerInfo.AddTotalDeaths();
-        playerRepository.UpdateTotalDeaths(deadPlayerInfo);
-
-        if (killer.IsInvalidPlayer())
-            return;
-
-        PlayerInfo killerInfo = killer.GetInfo();
-        killerInfo.StatsPerRound.AddKills();
-        killerInfo.AddTotalKills();
-        killer.AddScore();
-        playerRepository.UpdateTotalKills(killerInfo);
-        killingSpreeUpdater.Update(killer, killerInfo);
-        playerRankUpdater.Update(killer, killerInfo);
-        playerStatsRenderer.UpdateTextDraw(killer);
     }
 }


### PR DESCRIPTION
This PR has moved the code that updates the killer and dead player stats to the “PlayerStatsSystem” class. 
Why the change? It is a concern of "PlayerStatsSystem" to manage these updates from the "OnPlayerDeath" method, this also increases cohesion.

This refactor introduces a change to the API, but it is low impact.