### PR TITLE
fix: Avoid throwing an exception when an unauthenticated player disconnects

### DIFF
--- a/src/Application/Players/Accounts/Systems/PlayerStatsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerStatsSystem.cs
@@ -22,6 +22,9 @@ public class PlayerStatsSystem(
     [Event]
     public void OnPlayerDisconnect(Player player, DisconnectReason reason)
     {
+        if (player.IsUnauthenticated())
+            return;
+
         PlayerInfo playerInfo = player.GetInfo();
         playerInfo.SetLastConnection();
         playerRepository.UpdateLastConnection(playerInfo);


### PR DESCRIPTION
This change prevents unnecessary exceptions from being thrown when an unauthenticated player disconnects, improving the stability of the server.

If this check is not performed, this exception will be thrown when the player's last connection is updated:
```sh
System.Collections.Generic.KeyNotFoundException: The given key '-1' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
```