### PR TITLE
feat: Add Cooldowns to VIP Commands

### DIFF
--- a/src/Application/Players/Accounts/Systems/PlayerPointsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerPointsSystem.cs
@@ -4,7 +4,8 @@ public class PlayerPointsSystem(
     IEntityManager entityManager,
     IWorldService worldService,
     PlayerStatsRenderer playerStatsRenderer,
-    ServerTimeService serverTimeService) : ISystem
+    ServerTimeService serverTimeService,
+    CommandCooldowns commandCooldowns) : ISystem
 {
     [PlayerCommand("addpoints")]
     public void AddPointsToPlayer(
@@ -75,17 +76,19 @@ public class PlayerPointsSystem(
         if (currentPlayer.HasLowerRoleThan(RoleId.VIP))
             return;
 
-        const int Minutes = 4;
         var waitTimeComponent = currentPlayer.GetComponent<WaitTimeComponent>();
         if (waitTimeComponent.Value > serverTimeService.GetTime())
         {
-            var message = Smart.Format(Messages.TimeRequiredToReuseCommand, new { Minutes });
+            var message = Smart.Format(Messages.TimeRequiredToReuseCommand, new 
+            { 
+                Minutes = commandCooldowns.Coins
+            });
             currentPlayer.SendClientMessage(Color.Red, message);
             return;
         }
 
         static int ConvertMinutesToSeconds(int value) => value * 60;
-        int seconds = ConvertMinutesToSeconds(Minutes);
+        int seconds = ConvertMinutesToSeconds(commandCooldowns.Coins);
         waitTimeComponent.Value = serverTimeService.GetTime() + seconds;
         PlayerInfo currentPlayerInfo = currentPlayer.GetInfo();
         currentPlayerInfo.StatsPerRound.AddPoints(100);

--- a/src/Application/Players/CommandCooldowns.cs
+++ b/src/Application/Players/CommandCooldowns.cs
@@ -1,0 +1,23 @@
+﻿namespace CTF.Application.Players;
+
+/// <summary>
+/// Represents the reuse times for different commands in the game.
+/// </summary>
+/// <remarks>The times are expressed in minutes.</remarks>
+public class CommandCooldowns
+{
+    /// <summary>
+    /// Gets the reuse time for the health command in minutes.
+    /// </summary>
+    public int Health { get; init; } = 3;
+
+    /// <summary>
+    /// Gets the reuse time for the armour command in minutes.
+    /// </summary>
+    public int Armour { get; init; } = 3;
+
+    /// <summary>
+    /// Gets the reuse time for the coins command in minutes.
+    /// </summary>
+    public int Coins { get; init; } = 3;
+}

--- a/src/Application/Players/Vitalities/ArmourSystem.cs
+++ b/src/Application/Players/Vitalities/ArmourSystem.cs
@@ -3,7 +3,8 @@
 public class ArmourSystem(
     IWorldService worldService,
     IEntityManager entityManager,
-    ServerTimeService serverTimeService) : ISystem
+    ServerTimeService serverTimeService,
+    CommandCooldowns commandCooldowns) : ISystem
 {
     [PlayerCommand("addarmour")]
     public void AddArmourToPlayer(
@@ -74,17 +75,19 @@ public class ArmourSystem(
         if (currentPlayer.HasLowerRoleThan(RoleId.VIP))
             return;
 
-        const int Minutes = 4;
         var waitTimeComponent = currentPlayer.GetComponent<WaitTimeComponent>();
         if (waitTimeComponent.Value > serverTimeService.GetTime())
         {
-            var message = Smart.Format(Messages.TimeRequiredToReuseCommand, new { Minutes });
+            var message = Smart.Format(Messages.TimeRequiredToReuseCommand, new 
+            { 
+                Minutes = commandCooldowns.Armour
+            });
             currentPlayer.SendClientMessage(Color.Red, message);
             return;
         }
 
         static int ConvertMinutesToSeconds(int value) => value * 60;
-        int seconds = ConvertMinutesToSeconds(Minutes);
+        int seconds = ConvertMinutesToSeconds(commandCooldowns.Armour);
         waitTimeComponent.Value = serverTimeService.GetTime() + seconds;
         currentPlayer.Armour = 100;
     }

--- a/src/Application/Players/Vitalities/HealthSystem.cs
+++ b/src/Application/Players/Vitalities/HealthSystem.cs
@@ -3,7 +3,8 @@
 public class HealthSystem(
     IWorldService worldService,
     IEntityManager entityManager,
-    ServerTimeService serverTimeService) : ISystem
+    ServerTimeService serverTimeService,
+    CommandCooldowns commandCooldowns) : ISystem
 {
     [PlayerCommand("addhealth")]
     public void AddHealthToPlayer(
@@ -74,17 +75,19 @@ public class HealthSystem(
         if (currentPlayer.HasLowerRoleThan(RoleId.VIP))
             return;
 
-        const int Minutes = 4;
         var waitTimeComponent = currentPlayer.GetComponent<WaitTimeComponent>();
         if (waitTimeComponent.Value > serverTimeService.GetTime())
         {
-            var message = Smart.Format(Messages.TimeRequiredToReuseCommand, new { Minutes });
+            var message = Smart.Format(Messages.TimeRequiredToReuseCommand, new 
+            { 
+                Minutes = commandCooldowns.Health
+            });
             currentPlayer.SendClientMessage(Color.Red, message);
             return;
         }
 
         static int ConvertMinutesToSeconds(int value) => value * 60;
-        int seconds = ConvertMinutesToSeconds(Minutes);
+        int seconds = ConvertMinutesToSeconds(commandCooldowns.Health);
         waitTimeComponent.Value = serverTimeService.GetTime() + seconds;
         currentPlayer.Health = 100;
     }

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -13,12 +13,17 @@ public class Startup : IStartup
             .GetRequiredSection("ServerInfo")
             .Get<ServerSettings>();
 
+        var commandCooldowns = configuration
+            .GetRequiredSection("CommandCooldowns")
+            .Get<CommandCooldowns>();
+
         services.ChooseDatabaseProvider(configuration);
         services.AddApplicationServices();
         services
             .AddSingleton<IPasswordHasher, PasswordHasherBcrypt>()
             .AddSingleton<IStreamerService, StreamerService>()
-            .AddSingleton(serverSettings);
+            .AddSingleton(serverSettings)
+            .AddSingleton(commandCooldowns);
 
         // Add systems to the services collection
         services

--- a/src/Host/Usings.cs
+++ b/src/Host/Usings.cs
@@ -8,6 +8,7 @@ global using Microsoft.Extensions.Configuration;
 global using CTF.Application;
 global using CTF.Application.Common;
 global using CTF.Application.Common.Services;
+global using CTF.Application.Players;
 global using CTF.Host.Extensions;
 global using CTF.Host.Services;
 global using Persistence.SQLite;


### PR DESCRIPTION
This PR introduces the `CommandCooldowns` class, which centralizes the reuse times for various commands in the game, specifically for health, armour, and coins. Each property is initialized with a default value of 3 minutes.