### PR TITLE
BREAKING CHANGE: Replace 'Points' with 'Coins' for clarity

### DIFF
--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -79,6 +79,24 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {PlayerName} has generously given {Coins} coins to all the players!.
+        /// </summary>
+        internal static string AddCoinsToAllPlayers {
+            get {
+                return ResourceManager.GetString("AddCoinsToAllPlayers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You have given {Coins} coins to {PlayerName}.
+        /// </summary>
+        internal static string AddCoinsToPlayer {
+            get {
+                return ResourceManager.GetString("AddCoinsToPlayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {PlayerName} has added {Health}%% to the health of all players!.
         /// </summary>
         internal static string AddHealthToAllPlayers {
@@ -93,24 +111,6 @@ namespace CTF.Application.Common.Resources {
         internal static string AddHealthToPlayer {
             get {
                 return ResourceManager.GetString("AddHealthToPlayer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {PlayerName} has generously given {Points} points to all the players!.
-        /// </summary>
-        internal static string AddPointsToAllPlayers {
-            get {
-                return ResourceManager.GetString("AddPointsToAllPlayers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You have given {Points} points to {PlayerName}.
-        /// </summary>
-        internal static string AddPointsToPlayer {
-            get {
-                return ResourceManager.GetString("AddPointsToPlayer", resourceCulture);
             }
         }
         
@@ -250,29 +250,29 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have obtained 100 points!.
+        ///   Looks up a localized string similar to You have obtained 100 coins!.
         /// </summary>
-        internal static string GiveMePoints {
+        internal static string GiveMeCoins {
             get {
-                return ResourceManager.GetString("GiveMePoints", resourceCulture);
+                return ResourceManager.GetString("GiveMeCoins", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You do not have enough points to obtain this combo.
+        ///   Looks up a localized string similar to You do not have enough coins to obtain this combo.
         /// </summary>
-        internal static string InsufficientPoints {
+        internal static string InsufficientCoins {
             get {
-                return ResourceManager.GetString("InsufficientPoints", resourceCulture);
+                return ResourceManager.GetString("InsufficientCoins", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Points must be between 1 to 100.
+        ///   Looks up a localized string similar to Coins must be between 1 to 100.
         /// </summary>
-        internal static string InvalidAddPoints {
+        internal static string InvalidAddCoins {
             get {
-                return ResourceManager.GetString("InvalidAddPoints", resourceCulture);
+                return ResourceManager.GetString("InvalidAddCoins", resourceCulture);
             }
         }
         
@@ -331,11 +331,11 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Points must be between -1 to -100.
+        ///   Looks up a localized string similar to Coins must be between -1 to -100.
         /// </summary>
-        internal static string InvalidSubtractPoints {
+        internal static string InvalidSubtractCoins {
             get {
-                return ResourceManager.GetString("InvalidSubtractPoints", resourceCulture);
+                return ResourceManager.GetString("InvalidSubtractCoins", resourceCulture);
             }
         }
         
@@ -673,7 +673,7 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have gained +100 points, +100 armour, and +100 health.
+        ///   Looks up a localized string similar to You have gained +100 coins, +100 armour, and +100 health.
         /// </summary>
         internal static string RankUpAward {
             get {
@@ -691,20 +691,20 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Congratulations! You&apos;ve received {Coins} coins from {PlayerName}!.
+        /// </summary>
+        internal static string ReceiveCoinsFromPlayer {
+            get {
+                return ResourceManager.GetString("ReceiveCoinsFromPlayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Congratulations! You&apos;ve received {Health}%% health from {PlayerName}!.
         /// </summary>
         internal static string ReceiveHealthFromPlayer {
             get {
                 return ResourceManager.GetString("ReceiveHealthFromPlayer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Congratulations! You&apos;ve received {Points} points from {PlayerName}!.
-        /// </summary>
-        internal static string ReceivePointsFromPlayer {
-            get {
-                return ResourceManager.GetString("ReceivePointsFromPlayer", resourceCulture);
             }
         }
         
@@ -718,11 +718,11 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {PlayerName} redeemed their points for the combo: {ComboName}.
+        ///   Looks up a localized string similar to {PlayerName} redeemed their coins for the combo: {ComboName}.
         /// </summary>
-        internal static string RedeemedPoints {
+        internal static string RedeemedCoins {
             get {
-                return ResourceManager.GetString("RedeemedPoints", resourceCulture);
+                return ResourceManager.GetString("RedeemedCoins", resourceCulture);
             }
         }
         

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -123,17 +123,17 @@
   <data name="AddArmourToPlayer" xml:space="preserve">
     <value>You have added {Armour}%% armour to {PlayerName}!</value>
   </data>
+  <data name="AddCoinsToAllPlayers" xml:space="preserve">
+    <value>{PlayerName} has generously given {Coins} coins to all the players!</value>
+  </data>
+  <data name="AddCoinsToPlayer" xml:space="preserve">
+    <value>You have given {Coins} coins to {PlayerName}</value>
+  </data>
   <data name="AddHealthToAllPlayers" xml:space="preserve">
     <value>{PlayerName} has added {Health}%% to the health of all players!</value>
   </data>
   <data name="AddHealthToPlayer" xml:space="preserve">
     <value>You have added {Health}%% health to {PlayerName}!</value>
-  </data>
-  <data name="AddPointsToAllPlayers" xml:space="preserve">
-    <value>{PlayerName} has generously given {Points} points to all the players!</value>
-  </data>
-  <data name="AddPointsToPlayer" xml:space="preserve">
-    <value>You have given {Points} points to {PlayerName}</value>
   </data>
   <data name="AddScoreToAllPlayers" xml:space="preserve">
     <value>{PlayerName} has added {Score} to the score of all players!</value>
@@ -180,14 +180,14 @@
   <data name="GameModeDescription" xml:space="preserve">
     <value>~r~Welcome to Capture The Flag mode~n~~y~It is a game mode in which two teams (Alpha and Beta) compete to capture the other team's flag and bring it back to their own base to score a point</value>
   </data>
-  <data name="GiveMePoints" xml:space="preserve">
-    <value>You have obtained 100 points!</value>
+  <data name="GiveMeCoins" xml:space="preserve">
+    <value>You have obtained 100 coins!</value>
   </data>
-  <data name="InsufficientPoints" xml:space="preserve">
-    <value>You do not have enough points to obtain this combo</value>
+  <data name="InsufficientCoins" xml:space="preserve">
+    <value>You do not have enough coins to obtain this combo</value>
   </data>
-  <data name="InvalidAddPoints" xml:space="preserve">
-    <value>Points must be between 1 to 100</value>
+  <data name="InvalidAddCoins" xml:space="preserve">
+    <value>Coins must be between 1 to 100</value>
   </data>
   <data name="InvalidInterval" xml:space="preserve">
     <value>The interval must be between 0 to {Max}</value>
@@ -207,8 +207,8 @@
   <data name="InvalidSkin" xml:space="preserve">
     <value>Skin ID must be between 0 and 311</value>
   </data>
-  <data name="InvalidSubtractPoints" xml:space="preserve">
-    <value>Points must be between -1 to -100</value>
+  <data name="InvalidSubtractCoins" xml:space="preserve">
+    <value>Coins must be between -1 to -100</value>
   </data>
   <data name="InvalidTeam" xml:space="preserve">
     <value>Invalid team has been passed. Should be Alpha = 0, Beta = 1 or NoTeam = 255</value>
@@ -322,22 +322,22 @@
     <value>Promoted to {RoleName} role</value>
   </data>
   <data name="RankUpAward" xml:space="preserve">
-    <value>You have gained +100 points, +100 armour, and +100 health</value>
+    <value>You have gained +100 coins, +100 armour, and +100 health</value>
   </data>
   <data name="ReceiveArmourFromPlayer" xml:space="preserve">
     <value>Congratulations! You've received {Armour}%% armour from {PlayerName}!</value>
   </data>
+  <data name="ReceiveCoinsFromPlayer" xml:space="preserve">
+    <value>Congratulations! You've received {Coins} coins from {PlayerName}!</value>
+  </data>
   <data name="ReceiveHealthFromPlayer" xml:space="preserve">
     <value>Congratulations! You've received {Health}%% health from {PlayerName}!</value>
-  </data>
-  <data name="ReceivePointsFromPlayer" xml:space="preserve">
-    <value>Congratulations! You've received {Points} points from {PlayerName}!</value>
   </data>
   <data name="ReceiveScoreFromPlayer" xml:space="preserve">
     <value>Congratulations! You've received {Score} score from {PlayerName}!</value>
   </data>
-  <data name="RedeemedPoints" xml:space="preserve">
-    <value>{PlayerName} redeemed their points for the combo: {ComboName}</value>
+  <data name="RedeemedCoins" xml:space="preserve">
+    <value>{PlayerName} redeemed their coins for the combo: {ComboName}</value>
   </data>
   <data name="RedFlagIsNotAtBasePosition" xml:space="preserve">
     <value>~n~~n~~n~~r~The red flag is not at its base position</value>

--- a/src/Application/Players/Accounts/PlayerInfo.cs
+++ b/src/Application/Players/Accounts/PlayerInfo.cs
@@ -208,14 +208,14 @@ public partial class PlayerInfo
             StatsPerRound.Kills,
             StatsPerRound.Deaths,
             StatsPerRound.KillingSpree,
-            StatsPerRound.Points,
+            StatsPerRound.Coins,
             MaxRank = RankCollection.Count,
             Level = (int)RankId,
             RankName = rankResult.Value.Name
         };
         const string message = 
             "~w~KILLS: ~y~{Kills} ~w~DEATHS: ~y~{Deaths} ~w~SPREE: ~y~{KillingSpree} " +
-            "~w~POINTS: ~y~{Points}/100 ~w~LEVEL: ~y~{Level}/{MaxRank} ~w~RANK: ~y~{RankName}";
+            "~w~COINS: ~y~{Coins}/100 ~w~LEVEL: ~y~{Level}/{MaxRank} ~w~RANK: ~y~{RankName}";
         return Smart.Format(message, stats);
     }
 }

--- a/src/Application/Players/Accounts/PlayerStatsPerRound.cs
+++ b/src/Application/Players/Accounts/PlayerStatsPerRound.cs
@@ -5,39 +5,39 @@ public class PlayerStatsPerRound
     public int Kills { get; private set; }
     public int Deaths { get; private set; }
     public int KillingSpree { get; private set; }
-    public int Points { get; private set; }
+    public int Coins { get; private set; }
 
     public void AddKills() => Kills++;
     public void AddDeaths() => Deaths++;
     public void AddKillingSpree() => KillingSpree++;
-    public bool HasSufficientPoints(int amount) => Points >= amount;
-    public bool HasInsufficientPoints(int amount) => !HasSufficientPoints(amount);
+    public bool HasSufficientCoins(int amount) => Coins >= amount;
+    public bool HasInsufficientCoins(int amount) => !HasSufficientCoins(amount);
 
-    public Result AddPoints(int value)
+    public Result AddCoins(int value)
     {
         if (value < 1 || value > 100)
-            return Result.Failure(Messages.InvalidAddPoints);
+            return Result.Failure(Messages.InvalidAddCoins);
 
-        Points += value;
-        if(Points > 100) 
-            Points = 100;
+        Coins += value;
+        if(Coins > 100) 
+            Coins = 100;
 
         return Result.Success();
     }
 
-    public Result SubtractPoints(int value)
+    public Result SubtractCoins(int value)
     {
         if (value < -100 || value > -1)
-            return Result.Failure(Messages.InvalidSubtractPoints);
+            return Result.Failure(Messages.InvalidSubtractCoins);
 
-        Points -= -value;
-        if(Points < 0) 
-            Points = 0;
+        Coins -= -value;
+        if(Coins < 0) 
+            Coins = 0;
 
         return Result.Success();
     }
 
-    public void ResetPoints() => Points = 0;
+    public void ResetCoins() => Coins = 0;
     public void ResetKills()  => Kills = 0;
     public void ResetDeaths() => Deaths = 0;
     public void ResetKillingSpree() => KillingSpree = 0;
@@ -46,6 +46,6 @@ public class PlayerStatsPerRound
         Kills = 0;
         Deaths = 0;
         KillingSpree = 0;
-        Points = 0;
+        Coins = 0;
     }
 }

--- a/src/Application/Players/Accounts/Services/KillingSpreeUpdater.cs
+++ b/src/Application/Players/Accounts/Services/KillingSpreeUpdater.cs
@@ -11,8 +11,8 @@ public class KillingSpreeUpdater(
         if (currentKillingSpree >= 2)
         {
             player.GameText($"KILL X{currentKillingSpree}", 3000, 3);
-            const int earnedPoints = 20;
-            playerInfo.StatsPerRound.AddPoints(earnedPoints);
+            const int earnedCoins = 20;
+            playerInfo.StatsPerRound.AddCoins(earnedCoins);
             player.AddHealth(10);
 
             if (playerInfo.HasSurpassedMaxKillingSpree())

--- a/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
+++ b/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
@@ -11,7 +11,7 @@ public class PlayerRankUpdater(IPlayerRepository playerRepository)
             player.SendClientMessage(Color.Orange, Messages.RankUpAward);
             player.Armour = 100;
             player.Health = 100;
-            playerInfo.StatsPerRound.AddPoints(100);
+            playerInfo.StatsPerRound.AddCoins(100);
             playerInfo.SetRank(nextRank.Id);
             playerRepository.UpdateRank(playerInfo);
         }

--- a/src/Application/Players/Accounts/Systems/PlayerCoinsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerCoinsSystem.cs
@@ -1,23 +1,23 @@
 ﻿namespace CTF.Application.Players.Accounts.Systems;
 
-public class PlayerPointsSystem(
+public class PlayerCoinsSystem(
     IEntityManager entityManager,
     IWorldService worldService,
     PlayerStatsRenderer playerStatsRenderer,
     ServerTimeService serverTimeService,
     CommandCooldowns commandCooldowns) : ISystem
 {
-    [PlayerCommand("addpoints")]
-    public void AddPointsToPlayer(
+    [PlayerCommand("addcoins")]
+    public void AddCoinsToPlayer(
         Player currentPlayer,
         [CommandParameter(Name = "playerId")]Player targetPlayer,
-        int points)
+        int coins)
     {
         if (currentPlayer.HasLowerRoleThan(RoleId.Admin))
             return;
 
         PlayerInfo targetPlayerInfo = targetPlayer.GetInfo();
-        Result result = targetPlayerInfo.StatsPerRound.AddPoints(points);
+        Result result = targetPlayerInfo.StatsPerRound.AddCoins(coins);
         if (result.IsFailed)
         {
             currentPlayer.SendClientMessage(Color.Red, result.Message);
@@ -25,17 +25,17 @@ public class PlayerPointsSystem(
         }
 
         {
-            var message = Smart.Format(Messages.AddPointsToPlayer, new
+            var message = Smart.Format(Messages.AddCoinsToPlayer, new
             {
-                Points = points,
+                Coins = coins,
                 PlayerName = targetPlayer.Name
             });
             currentPlayer.SendClientMessage(Color.Yellow, message);
         }
         {
-            var message = Smart.Format(Messages.ReceivePointsFromPlayer, new
+            var message = Smart.Format(Messages.ReceiveCoinsFromPlayer, new
             {
-                Points = points,
+                Coins = coins,
                 PlayerName = currentPlayer.Name
             });
             targetPlayer.SendClientMessage(Color.Yellow, message);
@@ -43,8 +43,8 @@ public class PlayerPointsSystem(
         playerStatsRenderer.UpdateTextDraw(targetPlayer);
     }
 
-    [PlayerCommand("addallpoints")]
-    public void AddPointsToAllPlayers(Player currentPlayer, int points)
+    [PlayerCommand("addallcoins")]
+    public void AddCoinsToAllPlayers(Player currentPlayer, int coins)
     {
         if (currentPlayer.HasLowerRoleThan(RoleId.Admin))
             return;
@@ -53,7 +53,7 @@ public class PlayerPointsSystem(
         foreach (Player targetPlayer in players)
         {
             PlayerInfo targetPlayerInfo = targetPlayer.GetInfo();
-            Result result = targetPlayerInfo.StatsPerRound.AddPoints(points);
+            Result result = targetPlayerInfo.StatsPerRound.AddCoins(coins);
             if (result.IsFailed)
             {
                 currentPlayer.SendClientMessage(Color.Red, result.Message);
@@ -62,16 +62,16 @@ public class PlayerPointsSystem(
             playerStatsRenderer.UpdateTextDraw(targetPlayer);
         }
 
-        var message = Smart.Format(Messages.AddPointsToAllPlayers, new
+        var message = Smart.Format(Messages.AddCoinsToAllPlayers, new
         {
             PlayerName = currentPlayer.Name,
-            Points = points
+            Coins = coins
         });
         worldService.SendClientMessage(Color.Yellow, message);
     }
 
-    [PlayerCommand("givemepoints")]
-    public void GiveMePoints(Player currentPlayer) 
+    [PlayerCommand("givemecoins")]
+    public void GiveMeCoins(Player currentPlayer) 
     {
         if (currentPlayer.HasLowerRoleThan(RoleId.VIP))
             return;
@@ -91,9 +91,9 @@ public class PlayerPointsSystem(
         int seconds = ConvertMinutesToSeconds(commandCooldowns.Coins);
         waitTimeComponent.Value = serverTimeService.GetTime() + seconds;
         PlayerInfo currentPlayerInfo = currentPlayer.GetInfo();
-        currentPlayerInfo.StatsPerRound.AddPoints(100);
+        currentPlayerInfo.StatsPerRound.AddCoins(100);
         playerStatsRenderer.UpdateTextDraw(currentPlayer);
-        currentPlayer.SendClientMessage(Color.Yellow, Messages.GiveMePoints);
+        currentPlayer.SendClientMessage(Color.Yellow, Messages.GiveMeCoins);
     }
 
     [Event]

--- a/src/Application/Players/Accounts/Systems/PlayerStatsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerStatsSystem.cs
@@ -82,7 +82,7 @@ public class PlayerStatsSystem(
         Kills for Round: {playerInfo.StatsPerRound.Kills}
         Deaths for Round: {playerInfo.StatsPerRound.Deaths}
         Killing Spree for Round: {playerInfo.StatsPerRound.KillingSpree}
-        Points: {playerInfo.StatsPerRound.Points}/100
+        Coins: {playerInfo.StatsPerRound.Coins}/100
         Max Killing Spree: {playerInfo.MaxKillingSpree}
         Total Kills: {playerInfo.TotalKills}
         Total Deaths: {playerInfo.TotalDeaths}

--- a/src/Application/Players/Combos/ComboSystem.cs
+++ b/src/Application/Players/Combos/ComboSystem.cs
@@ -18,7 +18,7 @@ public class ComboSystem : ISystem
         var columnHeaders = new[]
         {
             "Combo",
-            "Required Points"
+            "Required Coins"
         };
         _tablistDialog = new TablistDialog(
             caption: "Combos",
@@ -27,7 +27,7 @@ public class ComboSystem : ISystem
             columnHeaders);
 
         foreach (ICombo combo in combos)
-            _tablistDialog.Add(combo.Name, combo.RequiredPoints.ToString());
+            _tablistDialog.Add(combo.Name, combo.RequiredCoins.ToString());
     }
 
     [PlayerCommand("combos")]
@@ -40,14 +40,14 @@ public class ComboSystem : ISystem
         string selectedItemName = response.Item.Columns[0];
         ICombo selectedCombo = _combos.First(combo => combo.Name == selectedItemName);
         PlayerStatsPerRound playerStats = player.GetInfo().StatsPerRound;
-        if(playerStats.HasInsufficientPoints(selectedCombo.RequiredPoints))
+        if(playerStats.HasInsufficientCoins(selectedCombo.RequiredCoins))
         {
-            player.SendClientMessage(Color.Red, Messages.InsufficientPoints);
+            player.SendClientMessage(Color.Red, Messages.InsufficientCoins);
             ShowCombos(player);
             return;
         }
 
-        var message = Smart.Format(Messages.RedeemedPoints, new 
+        var message = Smart.Format(Messages.RedeemedCoins, new 
         { 
             PlayerName  = player.Name,
             ComboName = selectedCombo.Name

--- a/src/Application/Players/Combos/ICombo.cs
+++ b/src/Application/Players/Combos/ICombo.cs
@@ -12,9 +12,9 @@ public interface ICombo
     string Name { get; }
 
     /// <summary>
-    /// Gets the required points that a player must have to acquire the combo.
+    /// Gets the required coins that a player must have to acquire the combo.
     /// </summary>
-    int RequiredPoints { get; }
+    int RequiredCoins { get; }
 
     /// <summary>
     /// Assigns a combo to a player, e.g., 100 Health and 100 Armour.

--- a/src/Application/Players/Combos/Services/FlamethrowerVitality.cs
+++ b/src/Application/Players/Combos/Services/FlamethrowerVitality.cs
@@ -3,7 +3,7 @@
 public class FlamethrowerVitality : ICombo
 {
     public string Name => "100 Health, 100 Armour and FlameThrower";
-    public int RequiredPoints => 100;
+    public int RequiredCoins => 100;
 
     public void Give(Player player)
     {
@@ -13,6 +13,6 @@ public class FlamethrowerVitality : ICombo
         // 1000 (shows in game as 50-50).
         const int ammo = 1000;
         player.GiveWeapon(Weapon.FlameThrower, ammo);
-        playerInfo.StatsPerRound.ResetPoints();
+        playerInfo.StatsPerRound.ResetCoins();
     }
 }

--- a/src/Application/Players/Combos/Services/GrenadesVitality.cs
+++ b/src/Application/Players/Combos/Services/GrenadesVitality.cs
@@ -3,7 +3,7 @@
 public class GrenadesVitality : ICombo
 {
     public string Name => "100 Health, 100 Armour and Grenades";
-    public int RequiredPoints => 100;
+    public int RequiredCoins => 100;
 
     public void Give(Player player)
     {
@@ -11,6 +11,6 @@ public class GrenadesVitality : ICombo
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.Grenade, ammo: 6);
-        playerInfo.StatsPerRound.ResetPoints();
+        playerInfo.StatsPerRound.ResetCoins();
     }
 }

--- a/src/Application/Players/Combos/Services/MolotovVitality.cs
+++ b/src/Application/Players/Combos/Services/MolotovVitality.cs
@@ -3,7 +3,7 @@
 public class MolotovVitality : ICombo
 {
     public string Name => "100 Health, 100 Armour and Molotov cocktail";
-    public int RequiredPoints => 100;
+    public int RequiredCoins => 100;
 
     public void Give(Player player)
     {
@@ -11,6 +11,6 @@ public class MolotovVitality : ICombo
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.Moltov, ammo: 6);
-        playerInfo.StatsPerRound.ResetPoints();
+        playerInfo.StatsPerRound.ResetCoins();
     }
 }

--- a/src/Application/Players/Combos/Services/SatchelChargesVitality.cs
+++ b/src/Application/Players/Combos/Services/SatchelChargesVitality.cs
@@ -3,7 +3,7 @@
 public class SatchelChargesVitality : ICombo
 {
     public string Name => "100 Health, 100 Armour and Satchel charges";
-    public int RequiredPoints => 100;
+    public int RequiredCoins => 100;
 
     public void Give(Player player)
     {
@@ -12,6 +12,6 @@ public class SatchelChargesVitality : ICombo
         player.Armour = 100;
         player.GiveWeapon(Weapon.SatchelCharge, ammo: 6);
         player.GiveWeapon(Weapon.Detonator, ammo: 1);
-        playerInfo.StatsPerRound.ResetPoints();
+        playerInfo.StatsPerRound.ResetCoins();
     }
 }

--- a/src/Application/Players/Combos/Services/TearGasVitality.cs
+++ b/src/Application/Players/Combos/Services/TearGasVitality.cs
@@ -3,7 +3,7 @@
 public class TearGasVitality : ICombo
 {
     public string Name => "100 Health, 100 Armour and Tear gas";
-    public int RequiredPoints => 100;
+    public int RequiredCoins => 100;
 
     public void Give(Player player)
     {
@@ -11,6 +11,6 @@ public class TearGasVitality : ICombo
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.Teargas, ammo: 15);
-        playerInfo.StatsPerRound.ResetPoints();
+        playerInfo.StatsPerRound.ResetCoins();
     }
 }

--- a/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
@@ -27,7 +27,7 @@ public class OnFlagCaptured(
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag captured!", 5000, 3);
 
         PlayerInfo playerInfo = player.GetInfo();
-        playerInfo.StatsPerRound.AddPoints(5);
+        playerInfo.StatsPerRound.AddCoins(5);
         playerInfo.AddCapturedFlags();
         player.AddScore(2);
         playerRepository.UpdateCapturedFlags(playerInfo);

--- a/src/Application/Teams/Flags/Events/OnFlagReturned.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagReturned.cs
@@ -29,7 +29,7 @@ public class OnFlagReturned(
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", 5000, 3);
 
         PlayerInfo playerInfo = player.GetInfo();
-        playerInfo.StatsPerRound.AddPoints(5);
+        playerInfo.StatsPerRound.AddCoins(5);
         playerInfo.AddReturnedFlags();
         player.AddScore(2);
         playerRepository.UpdateReturnedFlags(playerInfo);

--- a/src/Application/Teams/Flags/Events/OnFlagScore.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagScore.cs
@@ -30,7 +30,7 @@ public class OnFlagScore(
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} team scores!", 5000, 3);
 
         PlayerInfo playerInfo = player.GetInfo();
-        playerInfo.StatsPerRound.AddPoints(8);
+        playerInfo.StatsPerRound.AddCoins(8);
         playerInfo.AddBroughtFlags();
         player.AddScore(4);
         playerRepository.UpdateBroughtFlags(playerInfo);
@@ -43,7 +43,7 @@ public class OnFlagScore(
         foreach (Player player in teamMembers)
         {
             PlayerInfo playerInfo = player.GetInfo();
-            playerInfo.StatsPerRound.AddPoints(5);
+            playerInfo.StatsPerRound.AddCoins(5);
             player.AddHealth(10);
             player.AddScore(1);
             playerStatsRenderer.UpdateTextDraw(player);

--- a/src/Application/Teams/Flags/FlagSystem.cs
+++ b/src/Application/Teams/Flags/FlagSystem.cs
@@ -27,7 +27,7 @@ public class FlagSystem(
             if (killer.IsValidPlayer())
             {
                 PlayerInfo killerInfo = killer.GetInfo();
-                killerInfo.StatsPerRound.AddPoints(4);
+                killerInfo.StatsPerRound.AddCoins(4);
                 killer.AddHealth(10);
                 killer.AddScore(2);
                 playerStatsRenderer.UpdateTextDraw(killer);

--- a/tests/Application.Tests/Players/Accounts/PlayerInfoTests.cs
+++ b/tests/Application.Tests/Players/Accounts/PlayerInfoTests.cs
@@ -276,7 +276,7 @@ public class PlayerInfoTests
         int maxRank = RankCollection.Count;
         var expectedString =
             "~w~KILLS: ~y~0 ~w~DEATHS: ~y~0 ~w~SPREE: ~y~0 " +
-            $"~w~POINTS: ~y~0/100 ~w~LEVEL: ~y~0/{maxRank} ~w~RANK: ~y~Noob";
+            $"~w~COINS: ~y~0/100 ~w~LEVEL: ~y~0/{maxRank} ~w~RANK: ~y~Noob";
 
         // Act
         string actual = player.GetStatsAsText();

--- a/tests/Application.Tests/Players/Accounts/PlayerStatsPerRoundTests.cs
+++ b/tests/Application.Tests/Players/Accounts/PlayerStatsPerRoundTests.cs
@@ -5,14 +5,14 @@ public class PlayerStatsPerRoundTests
     [TestCase(10)]
     [TestCase(9)]
     [TestCase(8)]
-    public void HasSufficientPoints_WhenPlayerHasSufficientPoints_ShouldReturnsTrue(int amount)
+    public void HasSufficientCoins_WhenPlayerHasSufficientCoins_ShouldReturnsTrue(int amount)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        stats.AddPoints(10);
+        stats.AddCoins(10);
 
         // Act
-        bool actual = stats.HasSufficientPoints(amount);
+        bool actual = stats.HasSufficientCoins(amount);
 
         // Assert
         actual.Should().BeTrue();
@@ -20,14 +20,14 @@ public class PlayerStatsPerRoundTests
 
     [TestCase(11)]
     [TestCase(12)]
-    public void HasSufficientPoints_WhenPlayerHasInsufficientPoints_ShouldReturnsFalse(int amount)
+    public void HasSufficientCoins_WhenPlayerHasInsufficientCoins_ShouldReturnsFalse(int amount)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        stats.AddPoints(10);
+        stats.AddCoins(10);
 
         // Act
-        bool actual = stats.HasSufficientPoints(amount);
+        bool actual = stats.HasSufficientCoins(amount);
 
         // Assert
         actual.Should().BeFalse();
@@ -36,14 +36,14 @@ public class PlayerStatsPerRoundTests
     [TestCase(10)]
     [TestCase(9)]
     [TestCase(8)]
-    public void HasInsufficientPoints_WhenPlayerHasSufficientPoints_ShouldReturnsFalse(int amount)
+    public void HasInsufficientCoins_WhenPlayerHasSufficientCoins_ShouldReturnsFalse(int amount)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        stats.AddPoints(10);
+        stats.AddCoins(10);
 
         // Act
-        bool actual = stats.HasInsufficientPoints(amount);
+        bool actual = stats.HasInsufficientCoins(amount);
 
         // Assert
         actual.Should().BeFalse();
@@ -51,14 +51,14 @@ public class PlayerStatsPerRoundTests
 
     [TestCase(11)]
     [TestCase(12)]
-    public void HasInsufficientPoints_WhenPlayerHasInsufficientPoints_ShouldReturnsTrue(int amount)
+    public void HasInsufficientCoins_WhenPlayerHasInsufficientCoins_ShouldReturnsTrue(int amount)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        stats.AddPoints(10);
+        stats.AddCoins(10);
 
         // Act
-        bool actual = stats.HasInsufficientPoints(amount);
+        bool actual = stats.HasInsufficientCoins(amount);
 
         // Assert
         actual.Should().BeTrue();
@@ -67,14 +67,14 @@ public class PlayerStatsPerRoundTests
     [TestCase(0)]
     [TestCase(-1)]
     [TestCase(101)]
-    public void AddPoints_WhenPointsAreNotBetween1To100_ShouldReturnsFailureResult(int value)
+    public void AddCoins_WhenCoinsAreNotBetween1To100_ShouldReturnsFailureResult(int value)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        var expectedMessage = Messages.InvalidAddPoints;
+        var expectedMessage = Messages.InvalidAddCoins;
 
         // Act
-        Result result = stats.AddPoints(value);
+        Result result = stats.AddCoins(value);
 
         // Asserts
         result.IsSuccess.Should().BeFalse();
@@ -85,50 +85,50 @@ public class PlayerStatsPerRoundTests
     [TestCase(2)]
     [TestCase(99)]
     [TestCase(100)]
-    public void AddPoints_WhenPointsAreBetween1To100_ShouldReturnsSuccessResult(int value)
+    public void AddCoins_WhenCoinsAreBetween1To100_ShouldReturnsSuccessResult(int value)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
 
         // Act
-        Result result = stats.AddPoints(value);
+        Result result = stats.AddCoins(value);
 
         // Asserts
         result.IsSuccess.Should().BeTrue();
-        stats.Points.Should().Be(value);
+        stats.Coins.Should().Be(value);
     }
 
     [TestCase(21)]
     [TestCase(22)]
     [TestCase(23)]
     [TestCase(100)]
-    public void AddPoints_WhenSumOfPointsExceedsValueOf100_ShouldSetValueTo100(int value)
+    public void AddCoins_WhenSumOfCoinsExceedsValueOf100_ShouldSetValueTo100(int value)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        int expectedPoints = 100;
-        stats.AddPoints(80);
+        int expectedCoins = 100;
+        stats.AddCoins(80);
 
         // Act
-        Result result = stats.AddPoints(value);
+        Result result = stats.AddCoins(value);
 
         // Asserts
         result.IsSuccess.Should().BeTrue();
-        stats.Points.Should().Be(expectedPoints);
+        stats.Coins.Should().Be(expectedCoins);
     }
 
     [TestCase(0)]
     [TestCase(1)]
     [TestCase(-101)]
-    public void SubtractPoints_WhenPointsAreNotInSpecifiedRange_ShouldReturnsFailureResult(int value)
+    public void SubtractCoins_WhenCoinsAreNotInSpecifiedRange_ShouldReturnsFailureResult(int value)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
         // Should be in the range of -1 to -100.
-        var expectedMessage = Messages.InvalidSubtractPoints;
+        var expectedMessage = Messages.InvalidSubtractCoins;
 
         // Act
-        Result result = stats.SubtractPoints(value);
+        Result result = stats.SubtractCoins(value);
 
         // Asserts
         result.IsSuccess.Should().BeFalse();
@@ -139,37 +139,37 @@ public class PlayerStatsPerRoundTests
     [TestCase(-2)]
     [TestCase(-99)]
     [TestCase(-100)]
-    public void SubtractPoints_WhenPointsAreInSpecifiedRange_ShouldReturnsSuccessResult(int value)
+    public void SubtractCoins_WhenCoinsAreInSpecifiedRange_ShouldReturnsSuccessResult(int value)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        int expectedPoints = 0;
+        int expectedCoins = 0;
 
         // Act
-        Result result = stats.SubtractPoints(value);
+        Result result = stats.SubtractCoins(value);
 
         // Asserts
         result.IsSuccess.Should().BeTrue();
-        stats.Points.Should().Be(expectedPoints);
+        stats.Coins.Should().Be(expectedCoins);
     }
 
     [TestCase(-11)]
     [TestCase(-12)]
     [TestCase(-13)]
     [TestCase(-100)]
-    public void SubtractPoints_WhenSubtractionOfPointsGivesNegativeResult_ShouldSetValueToZero(int value)
+    public void SubtractCoins_WhenSubtractionOfCoinsGivesNegativeResult_ShouldSetValueToZero(int value)
     {
         // Arrange
         var stats = new PlayerStatsPerRound();
-        int expectedPoints = 0;
-        stats.AddPoints(10);
+        int expectedCoins = 0;
+        stats.AddCoins(10);
 
         // Act
-        Result result = stats.SubtractPoints(value);
+        Result result = stats.SubtractCoins(value);
 
         // Asserts
         result.IsSuccess.Should().BeTrue();
-        stats.Points.Should().Be(expectedPoints);
+        stats.Coins.Should().Be(expectedCoins);
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class PlayerStatsPerRoundTests
         stats.AddDeaths();
         stats.AddKillingSpree();
         stats.AddKillingSpree();
-        stats.AddPoints(15);
+        stats.AddCoins(15);
 
         // Act
         stats.ResetStats();
@@ -237,6 +237,6 @@ public class PlayerStatsPerRoundTests
         stats.Kills.Should().Be(0);
         stats.Deaths.Should().Be(0);
         stats.KillingSpree.Should().Be(0);
-        stats.Points.Should().Be(0);
+        stats.Coins.Should().Be(0);
     }
 }


### PR DESCRIPTION
The term “Points” was used in this game mode to allow the player to redeem it with a combo of benefits (such as weapons and vitality). This was the goal from the beginning, however, four days ago PR #118 was made to use the default SA-MP “score” (the one shown on the scoreboard when the tab key is clicked).

In this game mode the "score" is only used on the scoreboard, besides using it as a sorting criterion from the custom scoreboard that was created some time ago using the “/scoreboard” command.
This has caused a lot of confusion in the public API, since there is no clear difference between the terms used as “points” and “score”. 

The main problem is that “Points” is too generic, instead, the term “Coins” should have been used from the code and game.
This way, players are allowed to have up to 100 coins to redeem it with some combo and the important thing is that it is not confused with the term “score”.

**Note:** This introduces a high-impact breaking change to the API design, but it should not alter the behavior or functionality of the game mode.