### PR TITLE
feat!: Implement team balancer based on players' scores

### DIFF
--- a/src/Application/Teams/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ public static class TeamServicesExtensions
             .AddSingleton<TeamIconService>()
             .AddSingleton<TeamSoundsService>()
             .AddSingleton<TeamTextDrawRenderer>()
+            .AddSingleton<TeamBalancer>()
             .AddSingleton<FlagAutoReturnTimer>()
             .AddSingleton<ClassSelectionTextDrawRenderer>()
             .AddFlagServices();

--- a/src/Application/Teams/Services/TeamBalancer.cs
+++ b/src/Application/Teams/Services/TeamBalancer.cs
@@ -1,0 +1,53 @@
+﻿namespace CTF.Application.Teams.Services;
+
+/// <summary>
+/// Class responsible for balancing teams during map rotation.
+/// </summary>
+/// <remarks>
+/// This class was designed to be used only in <see cref="MapRotationService"/>.
+/// </remarks>
+public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
+{
+    /// <summary>
+    /// Balances the teams based on the players' scores.
+    /// </summary>
+    /// <param name="action">
+    /// The action to perform for each player after being assigned to a team.
+    /// </param>
+    /// <remarks>
+    /// This method sorts the players by score in descending order,
+    /// alternately assigns them to the Alpha and Beta teams.
+    /// </remarks>
+    public void Balance(Action<Player, PlayerInfo> action)
+    {
+        Player[] players = AlphaBetaTeamPlayers.GetAll()
+            .OrderByDescending(player => player.Score)
+            .ToArray();
+
+        Team alphaTeam = Team.Alpha;
+        Team betaTeam = Team.Beta;
+        alphaTeam.Reset();
+        betaTeam.Reset();
+
+        for (int index = 0; index < players.Length; index++)
+        {
+            Player player = players[index];
+            PlayerInfo playerInfo = player.GetInfo();
+            if (int.IsEvenInteger(index))
+            {
+                alphaTeam.Members.Add(player);
+                playerInfo.SetTeam(alphaTeam.Id);
+            }
+            else
+            {
+                betaTeam.Members.Add(player);
+                playerInfo.SetTeam(betaTeam.Id);
+            }
+            action.Invoke(player, playerInfo);
+        }
+        teamTextDrawRenderer.UpdateTeamScore(alphaTeam);
+        teamTextDrawRenderer.UpdateTeamScore(betaTeam);
+        teamTextDrawRenderer.UpdateTeamMembers(alphaTeam);
+        teamTextDrawRenderer.UpdateTeamMembers(betaTeam);
+    }
+}


### PR DESCRIPTION
## Previous behavior
When a new map is loaded, all players are redirected to class selection, causing them to wait for team availability, which negatively impacts the player experience.

## New behavior
When a new map is loaded, players are automatically assigned to teams (Alpha and Beta) based on their scores to maintain balance, and each player will be re-spawned on the new map.