### PR TITLE
ci: Use 'setup-mariadb' action instead of docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,14 @@ jobs:
       uses: ankane/setup-mariadb@v1
       with:
         database: gamemode
-        run: |
-         mariadb -uroot -e "CREATE USER 'admin'@'localhost' IDENTIFIED BY 'admin'"
-         mariadb -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'admin'@'localhost'"
-         mariadb -uroot -e "FLUSH PRIVILEGES"
-         mariadb -uroot gamemode < ./scripts/mariadb/gamemode.sql
     - name: Check MariaDB version
       run: mariadb --version
+    - name: Initialize MariaDB
+      run: |
+       mariadb -uroot -e "CREATE USER 'admin'@'localhost' IDENTIFIED BY 'admin'"
+       mariadb -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'admin'@'localhost'"
+       mariadb -uroot -e "FLUSH PRIVILEGES"
+       mariadb -uroot gamemode < ./scripts/mariadb/gamemode.sql
     - name: Check SQLite version
       run: sqlite3 --version
     - name: Create SQLite database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,31 +24,27 @@ jobs:
 
   integration_testing:
     runs-on: ubuntu-latest
-    services:
-      mariadb:
-        image: mariadb
-        ports:
-          - 3306:3306
-        env:
-          MARIADB_DATABASE: gamemode
-          MARIADB_ROOT_PASSWORD: 123456789
-        options: --name mariadb
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-    - name: Check sqlite3 version
+    - name: Install MariaDB
+      uses: ankane/setup-mariadb@v1
+      with:
+        database: gamemode
+        run: |
+         mariadb -uroot -e "CREATE USER 'admin'@'localhost' IDENTIFIED BY 'admin'"
+         mariadb -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'admin'@'localhost'"
+         mariadb -uroot -e "FLUSH PRIVILEGES"
+         mariadb -uroot gamemode < ./scripts/mariadb/gamemode.sql
+    - name: Check MariaDB version
+      run: mariadb --version
+    - name: Check SQLite version
       run: sqlite3 --version
-    - name: Waiting for database availability
-      run: |
-       chmod u+x wait-for-it.sh
-       ./wait-for-it.sh -t 60 127.0.0.1:3306
-    - name: Import databases
-      run: |
-       docker exec -i mariadb mariadb -uroot -p123456789 -h127.0.0.1 gamemode < ./scripts/mariadb/gamemode.sql
-       sqlite3 gamemode.db < ./scripts/sqlite/gamemode.sql
+    - name: Create SQLite database
+      run: sqlite3 gamemode.db < ./scripts/sqlite/gamemode.sql
     - name: Create .env.test file
       run: cp ./tests/Persistence.Tests/.env.test.example ./tests/Persistence.Tests/.env.test
     - name: Execute integration tests

--- a/tests/Persistence.Tests/.env.test.example
+++ b/tests/Persistence.Tests/.env.test.example
@@ -1,7 +1,7 @@
 MariaDB__Server=localhost
 MariaDB__Port=3306
 MariaDB__Database=gamemode
-MariaDB__UserName=root
-MariaDB__Password=123456789
+MariaDB__UserName=admin
+MariaDB__Password=admin
 
 SQLite__DataSource=/home/runner/work/Capture-The-Flag/Capture-The-Flag/gamemode.db


### PR DESCRIPTION
[I was using the MariaDb service with docker](https://github.com/MrDave1999/Capture-The-Flag/blob/6f3c012811c69ffb2225546aef802c1fb6718ffa/.github/workflows/ci.yml#L25-L55) but I get this error:
```sh
Run docker exec -i mariadb mariadb -uroot -p123456789 -h127.0.0.1 gamemode < ./scripts/mariadb/gamemode.sql
ERROR 2002 (HY000): Can't connect to server on '127.0.0.1' (115)
```
I have decided to use this action: https://github.com/ankane/setup-mariadb.
This way I can directly use the mariadb client instead of using **docker exec**.