### PR TITLE
chore: Add runtime identifier to use only native 32-bit libraries

### DIFF
--- a/src/Host/CTF.Host.csproj
+++ b/src/Host/CTF.Host.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x86</RuntimeIdentifier>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Persistence\Persistence.InMemory\Persistence.InMemory.csproj" />
@@ -18,7 +20,5 @@
     <PackageReference Include="DotEnv.Core" />
     <PackageReference Include="BCrypt.Net-Next" />
   </ItemGroup>
-
-  <Import Project="CopySQLiteLibrary.targets" />
 
 </Project>


### PR DESCRIPTION
Since SA-MP Server is 32-bit, the native libraries loaded must have the same architecture.