### PR TITLE
Revert "chore: Add runtime identifier to use only native 32-bit libraries (#198)"

### DIFF
--- a/src/Host/CTF.Host.csproj
+++ b/src/Host/CTF.Host.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,5 +18,7 @@
     <PackageReference Include="DotEnv.Core" />
     <PackageReference Include="BCrypt.Net-Next" />
   </ItemGroup>
+
+  <Import Project="CopySQLiteLibrary.targets" />
 
 </Project>


### PR DESCRIPTION
This reverts commit f6889e78a5d35e4aaa944127f848bfad06317076. 
This commit is reverted because it causes an error when building the docker image: 
```sh
error NETSDK1084: There is no application host available for the specified RuntimeIdentifier 'linux-x86'.
```