### PR TITLE
fix(sqlite): Remove 'REGEXP' operator from CHECK constraint

### DIFF
--- a/scripts/sqlite/gamemode.sql
+++ b/scripts/sqlite/gamemode.sql
@@ -5,8 +5,7 @@ CREATE TABLE IF NOT EXISTS players (
   CHECK(
     TRIM(name) != '' AND 
     LENGTH(name) >= 3 AND 
-    LENGTH(name) <= 20 AND 
-    name REGEXP '^[0-9a-zA-Z\[\]\(\)\$\@._=]+$'
+    LENGTH(name) <= 20
   ),
   password TEXT NOT NULL CHECK(TRIM(password) != ''),
   total_kills INTEGER NOT NULL CHECK(total_kills >= 0),


### PR DESCRIPTION
The 'REGEXP' operator is causing this exception when creating a player or updating the player name: 
```sh
'System.AccessViolationException' occurred in SQLitePCLRaw.provider.e_sqlite3.dll Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
```
The strange thing is that this exception only occurs when using the 32-bit e_sqlite.dll.