### PR TITLE
chore: Add support for .NET 6.0 to run game mode on Linux

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/src/Application/Common/CompilerServices.cs
+++ b/src/Application/Common/CompilerServices.cs
@@ -1,0 +1,22 @@
+﻿#if NET6_0
+namespace System.Runtime.CompilerServices;
+
+[AttributeUsage(
+    AttributeTargets.Class |
+    AttributeTargets.Field |
+    AttributeTargets.Property |
+    AttributeTargets.Struct,
+    AllowMultiple = false,
+    Inherited = false
+)]
+public class RequiredMemberAttribute : Attribute 
+{  
+    
+}
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+public class CompilerFeatureRequiredAttribute : Attribute
+{
+    public CompilerFeatureRequiredAttribute(string _) { }
+}
+#endif

--- a/src/Application/Common/Extensions/Int32Extensions.cs
+++ b/src/Application/Common/Extensions/Int32Extensions.cs
@@ -1,0 +1,6 @@
+﻿namespace CTF.Application.Common.Extensions;
+
+public static class Int32Extensions
+{
+    public static bool IsEvenInteger(this int value) => (value & 1) == 0;
+}

--- a/src/Application/Common/Extensions/RandomExtensions.cs
+++ b/src/Application/Common/Extensions/RandomExtensions.cs
@@ -1,0 +1,24 @@
+﻿#if NET6_0
+namespace CTF.Application.Common.Extensions;
+
+public static class RandomExtensions
+{
+    public static void Shuffle<T>(this Random random, T[] values)
+        => random.Shuffle(values.AsSpan());
+
+    private static void Shuffle<T>(this Random random, Span<T> values)
+    {
+        int n = values.Length;
+        for (int i = 0; i < n - 1; i++)
+        {
+            int j = random.Next(i, n);
+            if (j != i)
+            {
+                T temp = values[i];
+                values[i] = values[j];
+                values[j] = temp;
+            }
+        }
+    }
+}
+#endif

--- a/src/Application/Common/Services/TimeProvider.cs
+++ b/src/Application/Common/Services/TimeProvider.cs
@@ -1,0 +1,15 @@
+﻿#if NET6_0
+namespace CTF.Application.Common.Services;
+
+public abstract class TimeProvider
+{
+    public static TimeProvider System { get; } = new SystemTimeProvider();
+    public virtual DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
+    private class SystemTimeProvider : TimeProvider
+    {
+        internal SystemTimeProvider() : base()
+        {
+        }
+    }
+}
+#endif

--- a/src/Application/Players/Accounts/PlayerInfo.cs
+++ b/src/Application/Players/Accounts/PlayerInfo.cs
@@ -2,10 +2,13 @@
 
 public partial class PlayerInfo
 {
+    private const string PlayerNamePattern = @"^[0-9a-zA-Z\[\]\(\)\$\@._=]+$";
     private const int NoSkin = -1;
     private const int NoAccount = -1;
-    [GeneratedRegex(@"^[0-9a-zA-Z\[\]\(\)\$\@._=]+$")]
+    #if NET8_0_OR_GREATER
+    [GeneratedRegex(PlayerNamePattern)]
     private static partial Regex PlayerNameRegex();
+    #endif
 
     public PlayerInfo() { }
 
@@ -89,8 +92,13 @@ public partial class PlayerInfo
         if (value.Length < 3 || value.Length > 20)
             return Result.Failure(Messages.PlayerNameLength);
 
+        #if NET6_0
+        if (!Regex.IsMatch(value, PlayerNamePattern))
+            return Result.Failure(Messages.InvalidNickName);
+        #else
         if (!PlayerNameRegex().IsMatch(value))
             return Result.Failure(Messages.InvalidNickName);
+        #endif
 
         Name = value;
         return Result.Success();

--- a/src/Application/Teams/Services/TeamBalancer.cs
+++ b/src/Application/Teams/Services/TeamBalancer.cs
@@ -33,7 +33,7 @@ public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
         {
             Player player = players[index];
             PlayerInfo playerInfo = player.GetInfo();
-            if (int.IsEvenInteger(index))
+            if (index.IsEvenInteger())
             {
                 alphaTeam.Members.Add(player);
                 playerInfo.SetTeam(alphaTeam.Id);


### PR DESCRIPTION
This PR enables the game mode to run on Linux using the following runtime:
https://github.com/Servarr/dotnet-linux-x86/releases/tag/v6.0.32-96