### PR TITLE
refactor: Throw .env file not found exception only in DEBUG mode

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -5,7 +5,9 @@ public class Program
     static void Main(string[] args)
     {
         var envVars = new EnvLoader()
+            #if DEBUG
             .EnableFileNotFoundException()
+            #endif
             .AddEnvFile(".env")
             .Load();
 


### PR DESCRIPTION
This change is necessary because the ".env" file is not included in the docker image.
If the exception is thrown in release mode, the game server will never start.