### PR TITLE
chore: Remove platform-specific conditions from Copy task

### DIFF
--- a/src/Host/CopySQLiteLibrary.targets
+++ b/src/Host/CopySQLiteLibrary.targets
@@ -2,12 +2,10 @@
   <Target Name="CopySQLiteLibraryToOutputDir" AfterTargets="PostBuildEvent">
     <Message Importance="high" Text="OSPlatform: $(OS)" />
     <Copy
-      Condition="$([MSBuild]::IsOSPlatform('Windows'))"
       SourceFiles="bin\$(Configuration)\$(TargetFramework)\runtimes\win-x86\native\e_sqlite3.dll"
       DestinationFolder="$(OutputPath)"
     />
     <Copy
-      Condition="$([MSBuild]::IsOSPlatform('Linux'))"
       SourceFiles="bin\$(Configuration)\$(TargetFramework)\runtimes\linux-x86\native\libe_sqlite3.so"
       DestinationFolder="$(OutputPath)"
     />
@@ -17,12 +15,10 @@
     <Message Importance="high" Text="OutputPath: $(OutputPath)" />
     <Message Importance="high" Text="PublishDir: $(PublishDir)" />
     <Copy
-      Condition="$([MSBuild]::IsOSPlatform('Windows'))"
       SourceFiles="$(OutputPath)\e_sqlite3.dll"
       DestinationFolder="$(PublishDir)"
     />
     <Copy
-      Condition="$([MSBuild]::IsOSPlatform('Linux'))"
       SourceFiles="$(OutputPath)\libe_sqlite3.so"
       DestinationFolder="$(PublishDir)"
     />


### PR DESCRIPTION
This change was made because only `libe_sqlite3.so` is being included in the bin folder when the artifact is uploaded. This causes an exception when running the game mode on Windows.

It is no longer necessary to copy the SQLite library to the output directory based on the operating system, because the `Microsoft.Sqlite.Data` package already performs this check. It can automatically load either e_sqlite3.dll or libe_sqlite3.so depending on the platform.