### PR TITLE
refactor!: Remove method called HideLoadTimeForAll

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -97,7 +97,6 @@ public class MapRotationService(
     private void OnLoadedMap()
     {
         _isMapLoading = false;
-        mapTextDrawRenderer.HideLoadTimeForAll();
         TimeLeft.Reset();
         CurrentMap currentMap = mapInfoService.Read();
         string message = Smart.Format(Messages.MapSuccessfullyLoaded, new { currentMap.Name });

--- a/src/Application/Maps/Services/MapTextDrawRenderer.cs
+++ b/src/Application/Maps/Services/MapTextDrawRenderer.cs
@@ -26,6 +26,7 @@ public class MapTextDrawRenderer
         _mapName.Hide(player);
         _timer.Hide(player);
         _timeLeft.Hide(player);
+        _loadTime.Hide(player);
     }
 
     public void UpdateMapName(CurrentMap currentMap)
@@ -42,11 +43,6 @@ public class MapTextDrawRenderer
     {
         _loadTime.Text = loadTime.GameText;
         _loadTime.Show();
-    }
-
-    public void HideLoadTimeForAll()
-    {
-        _loadTime.Hide();
     }
 
     private void Initialize()


### PR DESCRIPTION
This PR removes the **HideLoadTimeForAll** method, as the **LoadTime** class already handles hiding the loading text when the time reaches zero, making it redundant.