### PR TITLE
feat: Create pause system for flag carriers with automatic flag return

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ ServerInfo__WebUrl=https://github.com/MrDave1999/Capture-The-Flag
 ServerInfo__IntroAudioUrl=https://od.lk/s/Nl8yMDg4MTc0NDBf/intro-cs.mp3
 # Expressed in seconds.
 ServerInfo__FlagAutoReturnTime=120
+# Expressed in seconds.
+ServerInfo__FlagCarrierPauseTime=30
 
 ServerOwner__Name=MrDave
 # Specify the secret key to give me admin.
@@ -53,4 +55,4 @@ MaxPlayers=30  # Number of players that can enter the SA-MP Server
 LagCompMode=1 # Lag Compensation
 Port=7777 # The port to be published by the container
 TZ=America/Bogota # Time Zone
-MemoryLimit=1g
+MemoryLimit=254m

--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -268,6 +268,15 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {ColorName} flag has returned to its base position after {PlayerName} was paused for {Seconds} seconds!.
+        /// </summary>
+        internal static string FlagAutoReturn2 {
+            get {
+                return ResourceManager.GetString("FlagAutoReturn2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ~r~Welcome to Capture The Flag mode~n~~y~It is a game mode in which two teams (Alpha and Beta) compete to capture the other team&apos;s flag and bring it back to their own base to score a point.
         /// </summary>
         internal static string GameModeDescription {

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -186,6 +186,9 @@
   <data name="FlagAutoReturn" xml:space="preserve">
     <value>The {ColorName} flag has automatically returned to its base position after {Seconds} seconds!</value>
   </data>
+  <data name="FlagAutoReturn2" xml:space="preserve">
+    <value>The {ColorName} flag has returned to its base position after {PlayerName} was paused for {Seconds} seconds!</value>
+  </data>
   <data name="GameModeDescription" xml:space="preserve">
     <value>~r~Welcome to Capture The Flag mode~n~~y~It is a game mode in which two teams (Alpha and Beta) compete to capture the other team's flag and bring it back to their own base to score a point</value>
   </data>

--- a/src/Application/Common/Settings/ServerSettings.cs
+++ b/src/Application/Common/Settings/ServerSettings.cs
@@ -9,4 +9,5 @@ public class ServerSettings
     public string WebUrl { get; init; } = string.Empty;
     public string IntroAudioUrl { get; init; } = string.Empty;
     public int FlagAutoReturnTime { get; init; } = 120;
+    public int FlagCarrierPauseTime { get; init; } = 30;
 }

--- a/src/Application/Teams/Flags/FlagAutoReturnTimer.cs
+++ b/src/Application/Teams/Flags/FlagAutoReturnTimer.cs
@@ -1,5 +1,8 @@
-﻿namespace CTF.Application.Teams.Services;
+﻿namespace CTF.Application.Teams.Flags;
 
+/// <summary>
+/// A timer service that automatically returns the flag to its base if it is not picked up by a player within a certain time limit.
+/// </summary>
 public class FlagAutoReturnTimer(
     ITimerService timerService,
     IWorldService worldService,

--- a/src/Application/Teams/Flags/FlagCarrierPauseHandler.cs
+++ b/src/Application/Teams/Flags/FlagCarrierPauseHandler.cs
@@ -1,0 +1,77 @@
+﻿namespace CTF.Application.Teams.Flags;
+
+/// <summary>
+/// A system that handles the pause logic for flag carriers.
+/// </summary>
+/// <remarks>
+/// It checks if the carrier is paused and updates the timer. If the timer runs out, the flag is returned to the base.
+/// </remarks>
+public class FlagCarrierPauseHandler(
+    IWorldService worldService,
+    ITimerService timerService,
+    TeamPickupService teamPickupService,
+    TeamSoundsService teamSoundsService,
+    ServerSettings serverSettings) : ISystem
+{
+    [Event]
+    public void OnPlayerDisconnect(Player player, DisconnectReason reason)
+    {
+        var pauseTimerReference = player.GetComponent<PauseTimerReference>();
+        if (pauseTimerReference is null)
+            return;
+
+        timerService.Stop(pauseTimerReference.Value);
+    }
+
+    [Event]
+    public void OnPlayerPauseStateChange(Player player, bool pauseState)
+    {
+        PlayerInfo playerInfo = player.GetInfo();
+        if (pauseState && playerInfo.HasCapturedFlag())
+        {
+            var interval = TimeSpan.FromSeconds(serverSettings.FlagCarrierPauseTime);
+            var timerReference = timerService.Start(OnComplete, interval);
+            player.AddComponent<PauseTimerReference>(timerReference);
+        }
+        else if (!pauseState && playerInfo.HasCapturedFlag())
+        {
+            var pauseTimerReference = player.GetComponent<PauseTimerReference>();
+            timerService.Stop(pauseTimerReference.Value);
+            pauseTimerReference.Destroy();
+        }
+
+        void OnComplete(IServiceProvider serviceProvider)
+        {
+            if (!player.IsComponentAlive)
+                return;
+
+            var pauseTimerReference = player.GetComponent<PauseTimerReference>();
+            timerService.Stop(pauseTimerReference.Value);
+            pauseTimerReference.Destroy();
+
+            if (!playerInfo.HasCapturedFlag())
+                return;
+
+            Team rivalTeam = playerInfo.Team.RivalTeam;
+            rivalTeam.IsFlagAtBasePosition = true;
+            rivalTeam.Flag.RemoveCarrier();
+            player.HideOnRadarMap();
+            teamPickupService.CreateFlagFromBasePosition(rivalTeam);
+            teamPickupService.DestroyExteriorMarker(rivalTeam);
+            teamSoundsService.PlayFlagReturnedSound(rivalTeam);
+            var message = Smart.Format(Messages.FlagAutoReturn2, new
+            {
+                rivalTeam.ColorName,
+                PlayerName = player.Name,
+                Seconds = serverSettings.FlagCarrierPauseTime
+            });
+            worldService.SendClientMessage(rivalTeam.ColorHex, message);
+            worldService.GameText($"~n~~n~~n~{rivalTeam.GameText}{rivalTeam.ColorName} flag returned!", 5000, 3);
+        }
+    }
+
+    private class PauseTimerReference(TimerReference value) : Component
+    {
+        public TimerReference Value { get; } = value;
+    }
+}

--- a/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class FlagServicesExtensions
             .AddSingleton<IFlagEvent, OnFlagScore>()
             .AddSingleton<IFlagEvent, OnFlagTaken>();
 
+        services.AddSingleton<FlagAutoReturnTimer>();
         services.AddSingleton<OnFlagDropped>();
         services.AddSingleton<IDictionary<FlagStatus, IFlagEvent>>(serviceProvider =>
         {

--- a/src/Application/Teams/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/ServiceCollectionExtensions.cs
@@ -10,7 +10,6 @@ public static class TeamServicesExtensions
             .AddSingleton<TeamSoundsService>()
             .AddSingleton<TeamTextDrawRenderer>()
             .AddSingleton<TeamBalancer>()
-            .AddSingleton<FlagAutoReturnTimer>()
             .AddSingleton<ClassSelectionTextDrawRenderer>()
             .AddFlagServices();
 


### PR DESCRIPTION
This PR introduces a pause system for flag carriers in the game, including the functionality for automatic flag return when the timer expires.

The purpose of this system is to prevent the game from stalling when a flag carrier enters pause mode. If the player does not return to the game within 30 seconds, the opposing team's flag will be automatically returned to its base.

This PR makes use of the [YSF](https://github.com/IS4Code/YSF) plugin (#229). 