### PR TITLE
fix: ensure paused players are not assigned to teams during balancing

### DIFF
--- a/src/Application/Teams/Services/TeamBalancer.cs
+++ b/src/Application/Teams/Services/TeamBalancer.cs
@@ -33,6 +33,17 @@ public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
         {
             Player player = players[index];
             PlayerInfo playerInfo = player.GetInfo();
+            if (player.IsPaused())
+            {
+                playerInfo.StatsPerRound.ResetStats();
+                playerInfo.SetTeam(TeamId.NoTeam);
+                player.Team = (int)TeamId.NoTeam;
+                player.Color = Team.None.ColorHex;
+                player.SetScore(0);
+                player.RedirectToClassSelection();
+                continue;
+            }
+
             if (index.IsEvenInteger())
             {
                 alphaTeam.Members.Add(player);
@@ -47,6 +58,7 @@ public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
             }
             action.Invoke(player, playerInfo);
         }
+
         teamTextDrawRenderer.UpdateTeamScore(alphaTeam);
         teamTextDrawRenderer.UpdateTeamScore(betaTeam);
         teamTextDrawRenderer.UpdateTeamMembers(alphaTeam);

--- a/src/Application/Usings.cs
+++ b/src/Application/Usings.cs
@@ -19,6 +19,7 @@ global using CTF.Application.Common.Services;
 global using CTF.Application.Common.Resources;
 global using CTF.Application.Common.Extensions;
 global using CTF.Application.Players;
+global using CTF.Application.Players.AFK;
 global using CTF.Application.Players.Accounts;
 global using CTF.Application.Players.Accounts.Services;
 global using CTF.Application.Players.Weapons;


### PR DESCRIPTION
Resolves #238 