### PR TITLE
refactor: Start the map rotation timer only if there are players online

### DIFF
--- a/src/Application/Maps/Systems/MapRotationSystem.cs
+++ b/src/Application/Maps/Systems/MapRotationSystem.cs
@@ -7,6 +7,8 @@ public class MapRotationSystem(
     MapRotationService mapRotationService,
     MapTextDrawRenderer mapTextDrawRenderer) : ISystem
 {
+    private int _connectedPlayers;
+
     [Event]
     public void OnPlayerSpawn(Player player)
     {
@@ -14,9 +16,19 @@ public class MapRotationSystem(
     }
 
     [Event]
-    public void OnGameModeInit()
+    public void OnPlayerConnect(Player player)
     {
-        mapRotationService.StartRotationTimer();
+        _connectedPlayers++;
+        if (_connectedPlayers == 1)
+            mapRotationService.StartRotationTimer();
+    }
+
+    [Event]
+    public void OnPlayerDisconnect(Player player, DisconnectReason reason) 
+    {
+        _connectedPlayers--;
+        if (_connectedPlayers == 0)
+            mapRotationService.StopRotationTimer();
     }
 
     [PlayerCommand("startrt")]


### PR DESCRIPTION
This change ensures that the map rotation timer only starts when there are players online, preventing unnecessary processes from running when no players are active. This also avoids creating unnecessary logs when the filterscripts are loaded/unloaded.

**Current behavior:**
- The timer starts only when there are players connected to the server.
- The timer stops when there are no players connected to the server.