### PR TITLE
feat: Add keyboard shortcuts for /weapons, /pack, and /combos commands

### DIFF
--- a/src/Application/Players/Combos/ComboSystem.cs
+++ b/src/Application/Players/Combos/ComboSystem.cs
@@ -33,6 +33,15 @@ public class ComboSystem : ISystem
             _tablistDialog.Add(combo.Name, combo.RequiredCoins.ToString());
     }
 
+    [Event]
+    public void OnPlayerKeyStateChange(Player player, Keys newKeys, Keys oldKeys)
+    {
+        if (KeyUtils.HasPressed(newKeys, oldKeys, Keys.AnalogLeft))
+        {
+            ShowCombos(player);
+        }
+    }
+
     [PlayerCommand("combos")]
     public async void ShowCombos(Player player)
     {

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -26,6 +26,19 @@ public class WeaponSystem : ISystem
     }
 
     [Event]
+    public void OnPlayerKeyStateChange(Player player, Keys newKeys, Keys oldKeys)
+    {
+        if (KeyUtils.HasPressed(newKeys, oldKeys, Keys.Yes))
+        {
+            ShowWeapons(player);
+        }
+        else if (KeyUtils.HasPressed(newKeys,oldKeys, Keys.CtrlBack))
+        {
+            ShowWeaponPackage(player);
+        }
+    }
+
+    [Event]
     public void OnPlayerSpawn(Player player)
     {
         var weaponSelection = player.GetComponent<WeaponSelectionComponent>();


### PR DESCRIPTION
* `/weapons` is now mapped to the 'Y' key.
* `/pack` is now mapped to the 'H' key.
* `/combos` is now mapped to the 'NUM 4' key.