### PR TITLE
feat: Award only 5 coins for headshots with the sniper

### DIFF
--- a/src/Application/Players/HeadShotSystem.cs
+++ b/src/Application/Players/HeadShotSystem.cs
@@ -35,7 +35,7 @@ public class HeadShotSystem(IPlayerRepository playerRepository) : ISystem
         {
             PlayerInfo issuerInfo = issuer.GetInfo();
             issuerInfo.AddHeadShots();
-            issuerInfo.StatsPerRound.AddCoins(10);
+            issuerInfo.StatsPerRound.AddCoins(5);
             playerRepository.UpdateHeadShots(issuerInfo);
             issuer.GameText("Headshot +1", 3000, 3);
             issuer.SendClientMessage(Color.Yellow, "Headshot +1");

--- a/src/Application/Players/HeadShotSystem.cs
+++ b/src/Application/Players/HeadShotSystem.cs
@@ -35,7 +35,7 @@ public class HeadShotSystem(IPlayerRepository playerRepository) : ISystem
         {
             PlayerInfo issuerInfo = issuer.GetInfo();
             issuerInfo.AddHeadShots();
-            issuerInfo.StatsPerRound.AddCoins(50);
+            issuerInfo.StatsPerRound.AddCoins(10);
             playerRepository.UpdateHeadShots(issuerInfo);
             issuer.GameText("Headshot +1", 3000, 3);
             issuer.SendClientMessage(Color.Yellow, "Headshot +1");


### PR DESCRIPTION
The reward for headshots with the sniper rifle has been reduced to 5 coins in order to better balance the in-game economy. This change helps distribute coins more fairly, preventing excessive accumulation from headshots and encouraging players to focus more on capturing the flag.

This PR is related to #260.