### PR TITLE
chore: update SampSharp to send an error message when command is not found

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="SampSharp.Entities" Version="0.10.1" />
     <PackageVersion Include="SampSharp.Streamer.Entities" Version="0.10.0" />
-    <PackageVersion Include="SampSharp.CTF.Entities" Version="0.10.9" />
+    <PackageVersion Include="SampSharp.CTF.Entities" Version="0.10.10" />
     <PackageVersion Include="SampSharp.CTF.Streamer.Entities" Version="0.10.1" />
     <PackageVersion Include="SmartFormat" Version="3.5.1" />
     <PackageVersion Include="MySqlConnector" Version="2.3.7" />


### PR DESCRIPTION
This PR overrides the default message:
> [SERVER] Unknown Command

The new message that will be displayed to the player is: 
> Command not found. To see all available commands, use /cmds

See https://github.com/MrDave1999/SampSharp/commit/731a93f8a67eea9baae3e5e466f5df5650699228