### PR TITLE
feat: send custom error message when player enters an unknown command

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="SampSharp.Entities" Version="0.10.1" />
     <PackageVersion Include="SampSharp.Streamer.Entities" Version="0.10.0" />
-    <PackageVersion Include="SampSharp.CTF.Entities" Version="0.10.10" />
+    <PackageVersion Include="SampSharp.CTF.Entities" Version="0.10.11" />
     <PackageVersion Include="SampSharp.CTF.Streamer.Entities" Version="0.10.1" />
     <PackageVersion Include="SmartFormat" Version="3.5.1" />
     <PackageVersion Include="MySqlConnector" Version="2.3.7" />

--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -214,6 +214,15 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Command not found. To see all available commands, use /cmds.
+        /// </summary>
+        internal static string CommandNotFound {
+            get {
+                return ResourceManager.GetString("CommandNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {PlayerName} has had {Kills} consecutive kills without dying.
         /// </summary>
         internal static string ConsecutiveKills {

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -168,6 +168,9 @@
   <data name="CommandLockMapLoading" xml:space="preserve">
     <value>You cannot execute commands while the map is loading</value>
   </data>
+  <data name="CommandNotFound" xml:space="preserve">
+    <value>Command not found. To see all available commands, use /cmds</value>
+  </data>
   <data name="ConsecutiveKills" xml:space="preserve">
     <value>{PlayerName} has had {Kills} consecutive kills without dying</value>
   </data>

--- a/src/Application/Players/PlayerCommandTextSystem.cs
+++ b/src/Application/Players/PlayerCommandTextSystem.cs
@@ -1,0 +1,30 @@
+﻿namespace CTF.Application.Players;
+
+public class PlayerCommandTextSystem(
+    IPlayerCommandService playerCommandService,
+    IServiceProvider serviceProvider) : ISystem
+{
+    /// <summary>
+    /// This callback is called when a player enters a command into the client chat window. 
+    /// Commands are anything that start with a forward slash, e.g. /help.
+    /// </summary>
+    /// <param name="player">
+    /// The player that entered a command.
+    /// </param>
+    /// <param name="text">
+    /// The command that was entered (including the forward slash).
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the command was processed, otherwise <c>false</c>; If the command was not found both in 
+    /// filterscripts and in gamemode, the player will be received a message: 'SERVER: Unknown command'.
+    /// </returns>
+    [Event]
+    public bool OnPlayerCommandText(Player player, string text)
+    {
+        bool invokeResult = playerCommandService.Invoke(serviceProvider, player, text);
+        if (!invokeResult)
+            player.SendClientMessage(Color.Red, Messages.CommandNotFound);
+
+        return true;
+    }
+}


### PR DESCRIPTION
In this PR #268 SampSharp was modified to send a custom message when the command is not found, but it is not necessary, since it can be done from the gamemode code without modifying the framework as such.