### PR TITLE
feat: allow players to send private messages to each other

### DIFF
--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -808,6 +808,33 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to That player has private messages blocked.
+        /// </summary>
+        internal static string PrivateMessagesBlocked {
+            get {
+                return ResourceManager.GetString("PrivateMessagesBlocked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Now players cannot send you a private message.
+        /// </summary>
+        internal static string PrivateMessagesDisabled {
+            get {
+                return ResourceManager.GetString("PrivateMessagesDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Now players can send you a private message.
+        /// </summary>
+        internal static string PrivateMessagesEnabled {
+            get {
+                return ResourceManager.GetString("PrivateMessagesEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Promoted to {RoleName} role.
         /// </summary>
         internal static string PromotedToRole {

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -366,6 +366,15 @@
   <data name="PlayerWithInsufficientHealth" xml:space="preserve">
     <value>You don't have enough health</value>
   </data>
+  <data name="PrivateMessagesBlocked" xml:space="preserve">
+    <value>That player has private messages blocked</value>
+  </data>
+  <data name="PrivateMessagesDisabled" xml:space="preserve">
+    <value>Now players cannot send you a private message</value>
+  </data>
+  <data name="PrivateMessagesEnabled" xml:space="preserve">
+    <value>Now players can send you a private message</value>
+  </data>
   <data name="PromotedToRole" xml:space="preserve">
     <value>Promoted to {RoleName} role</value>
   </data>

--- a/src/Application/Players/Chats/PrivateMessageSystem.cs
+++ b/src/Application/Players/Chats/PrivateMessageSystem.cs
@@ -1,0 +1,76 @@
+﻿namespace CTF.Application.Players.Chats;
+
+public class PrivateMessageSystem(IEntityManager entityManager) : ISystem
+{
+    [PlayerCommand("pm")]
+    public void SendMessageToPlayer(
+        Player sender,
+        [CommandParameter(Name = "playerId")]Player receiver,
+        string message)
+    {
+        if (sender == receiver)
+        {
+            sender.SendClientMessage(Color.Red, Messages.PlayerIsEqualsToTargetPlayer);
+            return;
+        }
+
+        var privateMessageComponent = receiver.GetComponent<PrivateMessageComponent>();
+        if (privateMessageComponent.IsBlocked) 
+        {
+            sender.SendClientMessage(Color.Red, Messages.PrivateMessagesBlocked);
+            return;
+        }
+
+        int senderId = sender.Entity.Handle;
+        int receiverId = receiver.Entity.Handle;
+        sender.SendClientMessage(Color.Yellow, $"PM to {receiver.Name}({receiverId}): {message}");
+        sender.PlaySound(1058);
+        receiver.SendClientMessage(Color.Yellow, $"PM from {sender.Name}({senderId}): {message}");
+        receiver.PlaySound(1058);
+
+        // Send private message to the STAFF.
+        var players = entityManager.GetComponents<Player>();
+        foreach (Player player in players)
+        {
+            PlayerInfo playerInfo = player.GetInfo();
+            if (playerInfo.HasLowerRoleThan(RoleId.Moderator))
+                continue;
+
+            // This prevents double messaging.
+            if (player == sender || player == receiver)
+                continue;
+
+            var messageForStaff = $"[PM] {sender.Name} writes to {receiver.Name}: {message}";
+            player.SendClientMessage(Color.Yellow, messageForStaff);
+        }
+    }
+
+    [PlayerCommand("blockpm")]
+    public void Block(Player player)
+    {
+        var privateMessageComponent = player.GetComponent<PrivateMessageComponent>();
+        privateMessageComponent.IsBlocked = true;
+        player.SendClientMessage(Color.Yellow, Messages.PrivateMessagesDisabled);
+        player.PlaySound(1139);
+    }
+
+    [PlayerCommand("unblockpm")]
+    public void Unblock(Player player)
+    {
+        var privateMessageComponent = player.GetComponent<PrivateMessageComponent>();
+        privateMessageComponent.IsBlocked = false;
+        player.SendClientMessage(Color.Yellow, Messages.PrivateMessagesEnabled);
+        player.PlaySound(1139);
+    }
+
+    [Event]
+    public void OnPlayerConnect(Player player) 
+    {
+        player.AddComponent<PrivateMessageComponent>();
+    }
+
+    private class PrivateMessageComponent : Component
+    {
+        public bool IsBlocked { get; set; }
+    }
+}

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
@@ -216,6 +216,9 @@ Beware! Enemies will see flag carriers on their radar as well!</value>
 {Color1}/report: {Color2}Report a player for inappropriate behavior.
 {Color1}/spec: {Color2}Spectate a specific player in the game.
 {Color1}/class: {Color2}Redirect to the class selection menu and enter AFK mode.
+{Color1}/pm: {Color2}Sends a private message to a player.
+{Color1}/blockpm: {Color2}Prevents players from sending you private messages.
+{Color1}/unblockpm: {Color2}Allows players to send you private messages.
 {Color1}/cmdsvip: {Color2}Display a list of commands available to VIP players.
 {Color1}/cmdsadmin: {Color2}Show the commands accessible to server administrators.
 {Color1}/cmdsmoderator: {Color2}Show the commands accessible to server moderators.</value>


### PR DESCRIPTION
## Commands
* `/pm`: Sends a private message to a player.
* `/blockpm`: Prevents players from sending you private messages.
* `/unblockpm`: Allows players to send you private messages.

Players who are moderators or admins will be able to see the private messages of all players for security reasons.