### PR TITLE
feat: allow players to use the rocket launcher if enabled by the STAFF

### DIFF
--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -250,11 +250,29 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {PlayerName} has disabled the Rocket Launcher(RPG).
+        /// </summary>
+        internal static string DisableRocketLauncher {
+            get {
+                return ResourceManager.GetString("DisableRocketLauncher", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You have no items in your weapon package.
         /// </summary>
         internal static string EmptyWeaponPackage {
             get {
                 return ResourceManager.GetString("EmptyWeaponPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {PlayerName} has enabled the Rocket Launcher(RPG). Use /combos or NUM 4 key.
+        /// </summary>
+        internal static string EnableRocketLauncher {
+            get {
+                return ResourceManager.GetString("EnableRocketLauncher", resourceCulture);
             }
         }
         
@@ -957,6 +975,15 @@ namespace CTF.Application.Common.Resources {
         internal static string ResetTeamStats {
             get {
                 return ResourceManager.GetString("ResetTeamStats", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The rocket launcher is disabled. It must be enabled by the STAFF.
+        /// </summary>
+        internal static string RocketLauncherDisabled {
+            get {
+                return ResourceManager.GetString("RocketLauncherDisabled", resourceCulture);
             }
         }
         

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -180,8 +180,14 @@
   <data name="DemotedToRole" xml:space="preserve">
     <value>Demoted to {RoleName} role</value>
   </data>
+  <data name="DisableRocketLauncher" xml:space="preserve">
+    <value>{PlayerName} has disabled the Rocket Launcher(RPG)</value>
+  </data>
   <data name="EmptyWeaponPackage" xml:space="preserve">
     <value>You have no items in your weapon package</value>
+  </data>
+  <data name="EnableRocketLauncher" xml:space="preserve">
+    <value>{PlayerName} has enabled the Rocket Launcher(RPG). Use /combos or NUM 4 key</value>
   </data>
   <data name="ExitSpectatorMode" xml:space="preserve">
     <value>To exit spectator mode use the command /class</value>
@@ -416,6 +422,9 @@
   </data>
   <data name="ResetTeamStats" xml:space="preserve">
     <value>{PlayerName} has reset the statistics of both teams (Alpha and Beta)</value>
+  </data>
+  <data name="RocketLauncherDisabled" xml:space="preserve">
+    <value>The rocket launcher is disabled. It must be enabled by the STAFF</value>
   </data>
   <data name="RoleSuccessfullyChanged" xml:space="preserve">
     <value>You have assigned the {RoleName} role to {PlayerName}</value>

--- a/src/Application/Players/Combos/ComboSettings.cs
+++ b/src/Application/Players/Combos/ComboSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace CTF.Application.Players.Combos;
+
+public class ComboSettings
+{
+    public bool IsRocketLauncherDisabled { get; set; } = true;
+}

--- a/src/Application/Players/Combos/ComboSystem.cs
+++ b/src/Application/Players/Combos/ComboSystem.cs
@@ -65,7 +65,10 @@ public class ComboSystem : ISystem
     {
         Result result = selectedCombo.Give(player);
         if (result.IsFailed)
+        {
+            ShowCombos(player);
             return;
+        }
 
         var message = Smart.Format(Messages.RedeemedCoins, new
         {

--- a/src/Application/Players/Combos/RocketLauncherSystem.cs
+++ b/src/Application/Players/Combos/RocketLauncherSystem.cs
@@ -1,0 +1,34 @@
+﻿namespace CTF.Application.Players.Combos;
+
+public class RocketLauncherSystem(
+    IWorldService worldService,
+    ComboSettings comboSettings) : ISystem
+{
+    [PlayerCommand("rpgon")]
+    public void EnableRocketLauncher(Player player)
+    {
+        if (player.HasLowerRoleThan(RoleId.Moderator))
+            return;
+
+        var message = Smart.Format(Messages.EnableRocketLauncher, new
+        {
+            PlayerName = player.Name
+        });
+        worldService.SendClientMessage(Color.Yellow, message);
+        comboSettings.IsRocketLauncherDisabled = false;
+    }
+
+    [PlayerCommand("rpgoff")]
+    public void DisableRocketLauncher(Player player)
+    {
+        if (player.HasLowerRoleThan(RoleId.Moderator))
+            return;
+
+        var message = Smart.Format(Messages.DisableRocketLauncher, new
+        {
+            PlayerName = player.Name
+        });
+        worldService.SendClientMessage(Color.Yellow, message);
+        comboSettings.IsRocketLauncherDisabled = true;
+    }
+}

--- a/src/Application/Players/Combos/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Combos/ServiceCollectionExtensions.cs
@@ -5,9 +5,11 @@ public static class ComboServicesExtensions
     public static IServiceCollection AddComboServices(this IServiceCollection services)
     {
         services
+            .AddSingleton<ComboSettings>()
             .AddSingleton<ICombo, FlamethrowerVitality>()
             .AddSingleton<ICombo, GrenadesVitality>()
             .AddSingleton<ICombo, MolotovVitality>()
+            .AddSingleton<ICombo, RocketLauncherVitality>()
             .AddSingleton<ICombo, SatchelChargesVitality>()
             .AddSingleton<ICombo, TearGasVitality>();
 

--- a/src/Application/Players/Combos/Services/RocketLauncherVitality.cs
+++ b/src/Application/Players/Combos/Services/RocketLauncherVitality.cs
@@ -1,0 +1,22 @@
+﻿namespace CTF.Application.Players.Combos.Services;
+
+public class RocketLauncherVitality(ComboSettings comboSettings) : ICombo
+{
+    public string Name => "100 Health and Rocket launcher(RPG)";
+    public int RequiredCoins => 100;
+
+    public Result Give(Player player)
+    {
+        if (comboSettings.IsRocketLauncherDisabled)
+        {
+            player.SendClientMessage(Color.Red, Messages.RocketLauncherDisabled);
+            return Result.Failure();
+        }
+
+        PlayerInfo playerInfo = player.GetInfo();
+        player.Health = 100;
+        player.GiveWeapon(Weapon.RocketLauncher, ammo: 2);
+        playerInfo.StatsPerRound.ResetCoins();
+        return Result.Success();
+    }
+}

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
@@ -119,7 +119,8 @@ namespace CTF.Application.Players.GeneralCommands.Resources {
         ///{Color1}/stoprt: {Color2}Stops the rotation timer for the current map.
         ///{Color1}/showrm: {Color2}Allows to show flag carriers on the radar map.
         ///{Color1}/hiderm: {Color2}Allows to hide flag carriers on the radar map.
-        ///{Color1}/rstats: {Color2}Reset the statistics of both teams (Alp [rest of string was truncated]&quot;;.
+        ///{Color1}/rpgon: {Color2}Enables the rocket launcher.
+        ///{Color1}/r [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Moderator {
             get {

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
@@ -169,6 +169,8 @@ Beware! Enemies will see flag carriers on their radar as well!</value>
 {Color1}/stoprt: {Color2}Stops the rotation timer for the current map.
 {Color1}/showrm: {Color2}Allows to show flag carriers on the radar map.
 {Color1}/hiderm: {Color2}Allows to hide flag carriers on the radar map.
+{Color1}/rpgon: {Color2}Enables the rocket launcher.
+{Color1}/rpgoff: {Color2}Disables the rocket launcher.
 {Color1}/rstats: {Color2}Reset the statistics of both teams (Alpha and Beta).
 {Color1}/kick: {Color2}Kicks a player from the game.
 {Color1}/warn: {Color2}Issues a warning to a player for inappropriate behavior.


### PR DESCRIPTION
Players can select the rocket launcher via the /combos command, if enabled by the STAFF.