### PR TITLE
feat: allow moderators to reset the flag to its base position

### DIFF
--- a/src/Application/Common/Resources/Messages.Designer.cs
+++ b/src/Application/Common/Resources/Messages.Designer.cs
@@ -385,6 +385,15 @@ namespace CTF.Application.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid color. Only &apos;red&apos; and &apos;blue&apos; are valid options for this command.
+        /// </summary>
+        internal static string InvalidFlagColor {
+            get {
+                return ResourceManager.GetString("InvalidFlagColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The interval must be between 0 to {Max}.
         /// </summary>
         internal static string InvalidInterval {
@@ -966,6 +975,15 @@ namespace CTF.Application.Common.Resources {
         internal static string ReportToAnotherPlayer {
             get {
                 return ResourceManager.GetString("ReportToAnotherPlayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {PlayerName} has reset the {ColorName} flag to its base position.
+        /// </summary>
+        internal static string ResetFlagPosition {
+            get {
+                return ResourceManager.GetString("ResetFlagPosition", resourceCulture);
             }
         }
         

--- a/src/Application/Common/Resources/Messages.resx
+++ b/src/Application/Common/Resources/Messages.resx
@@ -225,6 +225,9 @@
   <data name="InvalidAddCoins" xml:space="preserve">
     <value>Coins must be between 1 to 100</value>
   </data>
+  <data name="InvalidFlagColor" xml:space="preserve">
+    <value>Invalid color. Only 'red' and 'blue' are valid options for this command</value>
+  </data>
   <data name="InvalidInterval" xml:space="preserve">
     <value>The interval must be between 0 to {Max}</value>
   </data>
@@ -419,6 +422,9 @@
   </data>
   <data name="ReportToAnotherPlayer" xml:space="preserve">
     <value>{CurrentPlayer} reported to {TargetPlayer} [Reason: {Reason}]</value>
+  </data>
+  <data name="ResetFlagPosition" xml:space="preserve">
+    <value>{PlayerName} has reset the {ColorName} flag to its base position</value>
   </data>
   <data name="ResetPlayerStats" xml:space="preserve">
     <value>{PlayerName} has reset their stats, such as score, kills and deaths</value>

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
@@ -115,12 +115,11 @@ namespace CTF.Application.Players.GeneralCommands.Resources {
         /// <summary>
         ///   Looks up a localized string similar to {Color1}/maps: {Color2}Displays a list of available maps in the game.
         ///{Color1}/settimeleft: {Color2}Sets the remaining time for the current game session.
+        ///{Color1}/resetflag: {Color2}Resets the flag of a specific team to its base position.
         ///{Color1}/startrt: {Color2}Starts the rotation timer for the current map.
         ///{Color1}/stoprt: {Color2}Stops the rotation timer for the current map.
         ///{Color1}/showrm: {Color2}Allows to show flag carriers on the radar map.
-        ///{Color1}/hiderm: {Color2}Allows to hide flag carriers on the radar map.
-        ///{Color1}/rpgon: {Color2}Enables the rocket launcher.
-        ///{Color1}/r [rest of string was truncated]&quot;;.
+        ///{Color1}/hiderm: {Color2}Allows to hide flag carrie [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Moderator {
             get {

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
@@ -165,6 +165,7 @@ Beware! Enemies will see flag carriers on their radar as well!</value>
   <data name="Moderator" xml:space="preserve">
     <value>{Color1}/maps: {Color2}Displays a list of available maps in the game.
 {Color1}/settimeleft: {Color2}Sets the remaining time for the current game session.
+{Color1}/resetflag: {Color2}Resets the flag of a specific team to its base position.
 {Color1}/startrt: {Color2}Starts the rotation timer for the current map.
 {Color1}/stoprt: {Color2}Stops the rotation timer for the current map.
 {Color1}/showrm: {Color2}Allows to show flag carriers on the radar map.

--- a/src/Application/Teams/Flags/Systems/ResetFlagSystem.cs
+++ b/src/Application/Teams/Flags/Systems/ResetFlagSystem.cs
@@ -1,0 +1,49 @@
+﻿namespace CTF.Application.Teams.Flags.Systems;
+
+public class ResetFlagSystem(
+    IWorldService worldService,
+    TeamPickupService teamPickupService,
+    TeamSoundsService teamSoundsService,
+    FlagAutoReturnTimer flagAutoReturnTimer) : ISystem
+{
+    [PlayerCommand("resetflag")]
+    public void ResetToBasePosition(
+        Player player, 
+        [CommandParameter(Name = "red/blue")]string color)
+    {
+        if (player.HasLowerRoleThan(RoleId.Moderator))
+            return;
+
+        Team team = color.ToLower() switch
+        {
+            "red" => Team.Alpha,
+            "blue" => Team.Beta,
+            _ => null
+        };
+
+        if (team is null)
+        {
+            player.SendClientMessage(Color.Red, Messages.InvalidFlagColor);
+            return;
+        }
+
+        ResetFlagPosition(player, team);
+    }
+
+    private void ResetFlagPosition(Player player, Team team)
+    {
+        var message = Smart.Format(Messages.ResetFlagPosition, new
+        {
+            PlayerName = player.Name,
+            team.ColorName
+        });
+        team.IsFlagAtBasePosition = true;
+        team.Flag.RemoveCarrier();
+        teamPickupService.CreateFlagFromBasePosition(team);
+        teamPickupService.DestroyExteriorMarker(team);
+        teamSoundsService.PlayFlagReturnedSound(team);
+        flagAutoReturnTimer.Stop(team);
+        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", 5000, 3);
+        worldService.SendClientMessage(Color.Yellow, message);
+    }
+}


### PR DESCRIPTION
Added functionality for moderators to reset the flag if it's lost within the map or if the flag carrier moves outside the map boundaries.

Resolves #278 