### PR TITLE
fix: ensure flag carrier is hidden on radar map after flag reset

### DIFF
--- a/src/Application/Teams/Flags/Systems/ResetFlagSystem.cs
+++ b/src/Application/Teams/Flags/Systems/ResetFlagSystem.cs
@@ -38,8 +38,8 @@ public class ResetFlagSystem(
             team.ColorName
         });
         team.IsFlagAtBasePosition = true;
-        team.Flag.RemoveCarrier();
         team.Flag.Carrier?.HideOnRadarMap();
+        team.Flag.RemoveCarrier();
         teamPickupService.CreateFlagFromBasePosition(team);
         teamPickupService.DestroyExteriorMarker(team);
         teamSoundsService.PlayFlagReturnedSound(team);


### PR DESCRIPTION
The HideOnRadarMap method must be invoked before calling RemoveCarrier to ensure the Carrier property is not set to null. If RemoveCarrier is called first, HideOnRadarMap will not be called, resulting in the carrier still being visible on the radar map despite the flag reset.