### PR TITLE
feat: add option to disable anti-C-Bug via configuration file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ CommandCooldowns__Coins=3
 TopPlayers__RequiredTotalKills=150
 TopPlayers__RequiredMaxKillingSpree=10
 
+AntiCBug__Disabled=false
+
 MariaDB__Server=mariadb
 MariaDB__Port=3306
 MariaDB__Database=gamemode

--- a/src/Application/Players/AntiCBug/AntiCBugSettings.cs
+++ b/src/Application/Players/AntiCBug/AntiCBugSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace CTF.Application.Players.AntiCBug;
+
+public class AntiCBugSettings
+{
+    public bool Disabled { get; set; } = false;
+}

--- a/src/Application/Players/AntiCBug/AntiCBugSystem.cs
+++ b/src/Application/Players/AntiCBug/AntiCBugSystem.cs
@@ -1,6 +1,8 @@
 ﻿namespace CTF.Application.Players.AntiCBug;
 
-public class AntiCBugSystem(UnixTimeSeconds unixTimeSeconds) : ISystem
+public class AntiCBugSystem(
+    UnixTimeSeconds unixTimeSeconds,
+    AntiCBugSettings antiCBugSettings) : ISystem
 {
     [Event]
     public void OnPlayerConnect(Player player)
@@ -11,6 +13,9 @@ public class AntiCBugSystem(UnixTimeSeconds unixTimeSeconds) : ISystem
     [Event]
     public void OnPlayerKeyStateChange(Player player, Keys newKeys, Keys oldKeys)
     {
+        if (antiCBugSettings.Disabled)
+            return;
+
         if (player.State != PlayerState.OnFoot)
             return;
 

--- a/src/Host/Extensions/AppSettingsExtensions.cs
+++ b/src/Host/Extensions/AppSettingsExtensions.cs
@@ -26,12 +26,17 @@ public static class AppSettingsExtensions
             .GetRequiredSection("FlagCarrier")
             .Get<FlagCarrierSettings>();
 
+        var antiCBugSettings = configuration
+            .GetRequiredSection("AntiCBug")
+            .Get<AntiCBugSettings>();
+
         services
             .AddSingleton(serverSettings)
             .AddSingleton(commandCooldowns)
             .AddSingleton(topPlayersSettings)
             .AddSingleton(serverOwnerSettings)
-            .AddSingleton(flagCarrierSettings);
+            .AddSingleton(flagCarrierSettings)
+            .AddSingleton(antiCBugSettings);
 
         return services;
     }

--- a/src/Host/Usings.cs
+++ b/src/Host/Usings.cs
@@ -15,6 +15,7 @@ global using CTF.Application.Players;
 global using CTF.Application.Players.Accounts;
 global using CTF.Application.Players.AFK;
 global using CTF.Application.Players.Combos;
+global using CTF.Application.Players.AntiCBug;
 global using CTF.Application.Players.TopPlayers.Models;
 global using CTF.Application.Teams.Flags;
 global using CTF.Application.Teams.Flags.Systems;


### PR DESCRIPTION
**Crouch Bug (C-Bug)** is a bug in GTA: San Andreas that allows players to manipulate the reload animation of certain weapons, particularly the Desert Eagle, to fire much faster than the game’s normal mechanics would allow.

This PR is related to this one: https://github.com/MrDave1999/Capture-The-Flag/pull/304