### PR TITLE
chore: update SampSharp version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="SampSharp.Entities" Version="0.10.1" />
     <PackageVersion Include="SampSharp.Streamer.Entities" Version="0.10.0" />
-    <PackageVersion Include="SampSharp.CTF.Entities" Version="0.10.11" />
+    <PackageVersion Include="SampSharp.CTF.Entities" Version="0.10.12" />
     <PackageVersion Include="SampSharp.CTF.Streamer.Entities" Version="0.10.1" />
     <PackageVersion Include="SmartFormat" Version="3.5.2" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />


### PR DESCRIPTION
The SampSharp version has been updated.
The change includes:
* fix(ecs): Added a checker for invalid player IDs in parameterized commands. 
You can see more details in the commit here:
https://github.com/MrDave1999/SampSharp/commit/6099d946c00986f4b0965b061006a8441b922fcd