### PR TITLE
refactor(tests): replace complex TestCaseSource objects with enum-based provider + factory

### DIFF
--- a/tests/Persistence.Tests/Common/DatabaseProvider.cs
+++ b/tests/Persistence.Tests/Common/DatabaseProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace Persistence.Tests.Common;
+
+public enum DatabaseProvider
+{
+    InMemory,
+    MariaDb,
+    Sqlite
+}

--- a/tests/Persistence.Tests/Common/RepositoryManagerFactory.cs
+++ b/tests/Persistence.Tests/Common/RepositoryManagerFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace Persistence.Tests.Common;
+
+public class RepositoryManagerFactory
+{
+    public static IRepositoryManager Create(DatabaseProvider provider)
+    {
+        return provider switch
+        {
+            DatabaseProvider.InMemory => new InMemoryRepositoryManager(),
+            DatabaseProvider.MariaDb => new MariaDbRepositoryManager(),
+            DatabaseProvider.Sqlite => new SqliteRepositoryManager(),
+            _ => throw new NotSupportedException($"'{provider}' was not found as a database provider.")
+        };
+    }
+}

--- a/tests/Persistence.Tests/Common/RepositoryManagerTestCases.cs
+++ b/tests/Persistence.Tests/Common/RepositoryManagerTestCases.cs
@@ -1,12 +1,12 @@
 ﻿namespace Persistence.Tests.Common;
 
-public class RepositoryManagerTestCases : IEnumerable<IRepositoryManager>
+public class RepositoryManagerTestCases : IEnumerable<DatabaseProvider>
 {
-    public IEnumerator<IRepositoryManager> GetEnumerator()
+    public IEnumerator<DatabaseProvider> GetEnumerator()
     {
-        yield return new InMemoryRepositoryManager();
-        yield return new SqliteRepositoryManager();
-        yield return new MariaDbRepositoryManager();
+        yield return DatabaseProvider.InMemory;
+        yield return DatabaseProvider.Sqlite;
+        yield return DatabaseProvider.MariaDb;
     }
 
     IEnumerator IEnumerable.GetEnumerator()

--- a/tests/Persistence.Tests/Players/Create.cs
+++ b/tests/Persistence.Tests/Players/Create.cs
@@ -3,10 +3,10 @@
 public class CreatePlayer
 {
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void Create_WhenCalled_ShouldCreatePlayerAndSetAccountId(IRepositoryManager source)
+    public void Create_WhenCalled_ShouldCreatePlayerAndSetAccountId(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerInfo = new PlayerInfo();

--- a/tests/Persistence.Tests/Players/Exists.cs
+++ b/tests/Persistence.Tests/Players/Exists.cs
@@ -3,10 +3,10 @@
 public class PlayerExists
 {
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void Exists_WhenPlayerExists_ShouldReturnTrue(IRepositoryManager source)
+    public void Exists_WhenPlayerExists_ShouldReturnTrue(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "moderator_player";
@@ -19,10 +19,10 @@ public class PlayerExists
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void Exists_WhenPlayerDoesNotExist_ShouldReturnFalse(IRepositoryManager source)
+    public void Exists_WhenPlayerDoesNotExist_ShouldReturnFalse(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "NotFound";

--- a/tests/Persistence.Tests/Players/GetOrDefault.cs
+++ b/tests/Persistence.Tests/Players/GetOrDefault.cs
@@ -3,10 +3,10 @@
 public class GetPlayerOrDefault
 {
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void GetOrDefault_WhenPlayerExists_ShouldReturnPlayerInfo(IRepositoryManager source)
+    public void GetOrDefault_WhenPlayerExists_ShouldReturnPlayerInfo(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "moderator_player";
@@ -23,10 +23,10 @@ public class GetPlayerOrDefault
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void GetOrDefault_WhenPlayerDoesNotExist_ShouldReturnNull(IRepositoryManager source)
+    public void GetOrDefault_WhenPlayerDoesNotExist_ShouldReturnNull(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "NotFound";

--- a/tests/Persistence.Tests/Players/GetTopPlayers.cs
+++ b/tests/Persistence.Tests/Players/GetTopPlayers.cs
@@ -3,10 +3,10 @@
 public class GetTopPlayers
 {
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void GetByTotalKills_WhenSeedDataIsAvailable_ShouldReturnPlayersOrderedByTotalKills(IRepositoryManager source)
+    public void GetByTotalKills_WhenSeedDataIsAvailable_ShouldReturnPlayersOrderedByTotalKills(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         ITopPlayersRepository topPlayersRepository = repositoryManager.TopPlayersRepository;
         Result<MaxTopPlayers> result = MaxTopPlayers.Create(6);
@@ -30,10 +30,10 @@ public class GetTopPlayers
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void GetByTotalKills_WhenSeedDataIsNotAvailable_ShouldReturnEmptyCollection(IRepositoryManager source)
+    public void GetByTotalKills_WhenSeedDataIsNotAvailable_ShouldReturnEmptyCollection(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.RemoveSeedData();
         ITopPlayersRepository topPlayersRepository = repositoryManager.TopPlayersRepository;
         Result<MaxTopPlayers> result = MaxTopPlayers.Create(6);
@@ -48,10 +48,10 @@ public class GetTopPlayers
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void GetByMaxKillingSpree_WhenSeedDataIsAvailable_ShouldReturnPlayersOrderedByMaxKillingSpree(IRepositoryManager source)
+    public void GetByMaxKillingSpree_WhenSeedDataIsAvailable_ShouldReturnPlayersOrderedByMaxKillingSpree(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         ITopPlayersRepository topPlayersRepository = repositoryManager.TopPlayersRepository;
         Result<MaxTopPlayers> result = MaxTopPlayers.Create(6);
@@ -75,10 +75,10 @@ public class GetTopPlayers
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void GetByMaxKillingSpree_WhenSeedDataIsNotAvailable_ShouldReturnEmptyCollection(IRepositoryManager source)
+    public void GetByMaxKillingSpree_WhenSeedDataIsNotAvailable_ShouldReturnEmptyCollection(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.RemoveSeedData();
         ITopPlayersRepository topPlayersRepository = repositoryManager.TopPlayersRepository;
         Result<MaxTopPlayers> result = MaxTopPlayers.Create(6);

--- a/tests/Persistence.Tests/Players/Update.cs
+++ b/tests/Persistence.Tests/Players/Update.cs
@@ -3,10 +3,10 @@
 public class UpdatePlayer
 {
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdatePlayerName(IRepositoryManager source)
+    public void ShouldUpdatePlayerName(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var oldName = "Moderator_Player";
@@ -23,10 +23,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdatePlayerPassword(IRepositoryManager source)
+    public void ShouldUpdatePlayerPassword(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -43,10 +43,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateTotalKills(IRepositoryManager source)
+    public void ShouldUpdateTotalKills(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -63,10 +63,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateTotalDeaths(IRepositoryManager source)
+    public void ShouldUpdateTotalDeaths(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -83,10 +83,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateMaxKillingSpree(IRepositoryManager source)
+    public void ShouldUpdateMaxKillingSpree(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -103,10 +103,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateBroughtFlags(IRepositoryManager source)
+    public void ShouldUpdateBroughtFlags(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -124,10 +124,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateCapturedFlags(IRepositoryManager source)
+    public void ShouldUpdateCapturedFlags(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -145,10 +145,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateDroppedFlags(IRepositoryManager source)
+    public void ShouldUpdateDroppedFlags(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -166,10 +166,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateReturnedFlags(IRepositoryManager source)
+    public void ShouldUpdateReturnedFlags(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -187,10 +187,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateHeadShots(IRepositoryManager source)
+    public void ShouldUpdateHeadShots(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -208,10 +208,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateRole(IRepositoryManager source)
+    public void ShouldUpdateRole(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -228,10 +228,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateSkin(IRepositoryManager source)
+    public void ShouldUpdateSkin(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -248,10 +248,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateRank(IRepositoryManager source)
+    public void ShouldUpdateRank(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";
@@ -268,10 +268,10 @@ public class UpdatePlayer
     }
 
     [TestCaseSource(typeof(RepositoryManagerTestCases))]
-    public void ShouldUpdateLastConnection(IRepositoryManager source)
+    public void ShouldUpdateLastConnection(DatabaseProvider provider)
     {
         // Arrange
-        using var repositoryManager = source;
+        using IRepositoryManager repositoryManager = RepositoryManagerFactory.Create(provider);
         repositoryManager.InitializeSeedData();
         IPlayerRepository playerRepository = repositoryManager.PlayerRepository;
         var playerName = "Moderator_Player";


### PR DESCRIPTION
NUnit occasionally failed in GitHub Actions with a `NullReferenceException` in `CreatePlayer` tests when using `RepositoryManagerTestCases`. The root cause was NUnit’s internal cloning/serialization behavior: complex objects returned by
TestCaseSource can be cloned using `GetUninitializedObject`, bypassing their constructors and producing partially-initialized instances (e.g., DI-managed repositories set to null). 
This happens before the test lifecycle begins and outside the test context, which explains why failures were intermittent and
only reproduced in CI.

This refactor replaces complex test case objects with a simple enum (`DatabaseProvider`). `IRepositoryManager` instances are now created inside the test via a dedicated factory, guaranteeing:
- Objects are instantiated within the test’s lifecycle.
- NUnit no longer clones or serializes DI-based classes.
- Stable behavior across local runs and GitHub Actions.
- Proper debugging, since constructors now execute predictably.
- Fully isolated tests with no pre-initialized or shared state.

All tests were updated to use the new enum-based provider and factory pattern.
