### PR TITLE
Replace server.cfg patching with config.json updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,7 @@ COPY ["filterscripts/*.amx", "filterscripts/"]
 COPY ["codepages/*.txt", "codepages/"]
 COPY ["plugins/*.so", "components/"]
 COPY ["config.json", "config.json"]
+COPY ["entrypoint.sh", "entrypoint.sh"]
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl \
     libstdc++6 \
     libatomic1 \
+    jq \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build: .
     env_file: .env
     mem_limit: ${MemoryLimit}
-    command: ./entrypoint.sh
     ports:
       - ${Port}:${Port}/udp
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     build: .
     env_file: .env
     mem_limit: ${MemoryLimit}
-    command: >
-      bash -c "./omp-server"
+    command: ./entrypoint.sh
     ports:
       - ${Port}:${Port}/udp
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 echo "Starting entrypoint..."
-echo "Port=$Port"
+echo "LagCompMode=$LagCompMode"
 echo "MaxPlayers=$MaxPlayers"
+echo "Port=$Port"
+echo "ServerPassword=$ServerPassword"
 
 jq "
   .game.lag_compensation_mode = ${LagCompMode}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "Starting entrypoint..."
+echo "Port=$Port"
+echo "MaxPlayers=$MaxPlayers"
+
 jq "
   .game.lag_compensation_mode = ${LagCompMode}
   | .max_players = ${MaxPlayers}
@@ -9,4 +13,5 @@ jq "
 
 mv config.tmp config.json
 
+echo "Launching omp-server..."
 exec ./omp-server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+jq "
+  .game.lag_compensation_mode = ${LagCompMode}
+  | .max_players = ${MaxPlayers}
+  | .network.port = ${Port}
+  | .password = \"${ServerPassword}\"
+" config.json > config.tmp
+
+mv config.tmp config.json
+
+exec ./omp-server


### PR DESCRIPTION
Migrate container configuration from server.cfg to open.mp config.json.

Replace legacy sed-based configuration patching with a dedicated entrypoint script that updates config.json using `jq`. This keeps environment-based configuration support while aligning the deployment process with the current open.mp server configuration format.