### PR TITLE
refactor!: replace static MapCollection with instance-based service

### DIFF
--- a/src/Application/Maps/MapCollection.cs
+++ b/src/Application/Maps/MapCollection.cs
@@ -2,56 +2,43 @@
 
 public class MapCollection
 {
-    private static Map[] s_maps;
-    static MapCollection() => SetMapNamesFromFileSystem();
-    private static void SetMapNamesFromFileSystem()
+    private Map[] _maps;
+
+    public MapCollection(string path)
     {
-        var path = GameModePaths.Maps;
-        var random = new Random();
-        string[] names = Directory.GetFiles(path);
-        random.Shuffle(names);
-        s_maps = new Map[names.Length];
-        for (int i = 0; i < names.Length; i++)
-        {
-            var map = new Map 
-            { 
-                Id = i, 
-                Name = Path.GetFileNameWithoutExtension(names[i])
-            };
-            s_maps[i] = map;
-        }
+        LoadFromDirectory(path);
     }
 
-    public static int Count => s_maps.Length;
-    public static IReadOnlyList<IMap> GetAll() => s_maps;
-    public static IEnumerable<IMap> GetAll(string findBy)
+    public int Count => _maps.Length;
+    public IReadOnlyList<IMap> GetAll() => _maps;
+    public IEnumerable<IMap> GetAll(string findBy)
     {
-        foreach(Map map in s_maps) 
+        foreach(Map map in _maps) 
         { 
             if (map.Name.StartsWith(findBy, StringComparison.OrdinalIgnoreCase))
                 yield return map;
         }
     }
 
-    public static Result<IMap> GetById(int id)
+    public Result<IMap> GetById(int id)
     {
         if (id < 0 || id >= Count)
             return Result<IMap>.Failure(Messages.InvalidMap);
 
-        Map map = s_maps[id];
+        Map map = _maps[id];
         return Result<IMap>.Success(map);
     }
 
-    public static Result<IMap> GetByName(string mapName)
+    public Result<IMap> GetByName(string mapName)
     {
-        Map map = s_maps
+        Map map = _maps
             .FirstOrDefault(map => map.Name.Equals(mapName, StringComparison.OrdinalIgnoreCase));
         return map is null ?
             Result<IMap>.Failure(Messages.MapNotFound) :
             Result<IMap>.Success(map);
     }
 
-    public static IMap GetNext(IMap current)
+    public IMap GetNext(IMap current)
     {
         int nextMapId = (current.Id + 1) % Count;
         return GetById(nextMapId).Value;
@@ -61,5 +48,22 @@ public class MapCollection
     {
         public int Id { get; init; }
         public string Name { get; init; }
+    }
+
+    private void LoadFromDirectory(string path)
+    {
+        var random = new Random();
+        string[] names = Directory.GetFiles(path);
+        random.Shuffle(names);
+        _maps = new Map[names.Length];
+        for (int i = 0; i < names.Length; i++)
+        {
+            var map = new Map
+            {
+                Id = i,
+                Name = Path.GetFileNameWithoutExtension(names[i])
+            };
+            _maps[i] = map;
+        }
     }
 }

--- a/src/Application/Maps/ServiceCollectionExtensions.cs
+++ b/src/Application/Maps/ServiceCollectionExtensions.cs
@@ -7,7 +7,8 @@ public static class MapServicesExtensions
         services
             .AddSingleton<MapInfoService>()
             .AddSingleton<MapRotationService>()
-            .AddSingleton<MapTextDrawRenderer>();
+            .AddSingleton<MapTextDrawRenderer>()
+            .AddSingleton(_ => new MapCollection(GameModePaths.Maps));
 
         return services;
     }

--- a/src/Application/Maps/Services/MapInfoService.cs
+++ b/src/Application/Maps/Services/MapInfoService.cs
@@ -6,10 +6,10 @@
 public class MapInfoService
 {
     private CurrentMap _currentMap;
-    public MapInfoService()
+    public MapInfoService(MapCollection mapCollection)
     {
         int defaultMapId = 0;
-        IMap defaultMap = MapCollection.GetById(defaultMapId).Value;
+        IMap defaultMap = mapCollection.GetById(defaultMapId).Value;
         Load(defaultMap);
     }
 

--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -5,6 +5,7 @@ public class MapRotationService(
     IWorldService worldService,
     ITimerService timerService,
     MapInfoService mapInfoService,
+    MapCollection mapCollection,
     MapTextDrawRenderer mapTextDrawRenderer,
     TeamIconService teamIconService,
     TeamPickupService teamPickupService,
@@ -18,7 +19,7 @@ public class MapRotationService(
     private readonly TimeLeft _timeLeft = new();
     public TimeLeft TimeLeft => _timeLeft;
     public bool IsMapLoading => _isMapLoading;
-    public IMap NextMap => _forcedNextMap ?? MapCollection.GetNext(mapInfoService.CurrentMap);
+    public IMap NextMap => _forcedNextMap ?? mapCollection.GetNext(mapInfoService.CurrentMap);
 
     public delegate void LoadingMapEventHandler();
     public delegate void LoadedMapEventHandler();

--- a/src/Application/Maps/Systems/MapRotationSystem.cs
+++ b/src/Application/Maps/Systems/MapRotationSystem.cs
@@ -4,6 +4,7 @@ public class MapRotationSystem(
     IWorldService worldService,
     IDialogService dialogService,
     MapRotationService mapRotationService,
+    MapCollection mapCollection,
     MapTextDrawRenderer mapTextDrawRenderer) : ISystem
 {
     private int _connectedPlayers;
@@ -73,9 +74,9 @@ public class MapRotationSystem(
             return;
 
         var listDialog = new ListDialog(string.Empty, "Select", "Close");
-        IEnumerable<IMap> maps = string.IsNullOrEmpty(findBy) ? 
-            MapCollection.GetAll() : 
-            MapCollection.GetAll(findBy);
+        IEnumerable<IMap> maps = string.IsNullOrEmpty(findBy) ?
+            mapCollection.GetAll() :
+            mapCollection.GetAll(findBy);
 
         IMap nextMap = mapRotationService.NextMap;
         foreach (IMap map in maps)
@@ -92,12 +93,12 @@ public class MapRotationSystem(
             return;
         }
 
-        listDialog.Caption = $"Maps: {listDialog.Rows.Count}/{MapCollection.Count}";
+        listDialog.Caption = $"Maps: {listDialog.Rows.Count}/{mapCollection.Count}";
         ListDialogResponse listDialogResponse = await dialogService.ShowAsync(player, listDialog);
         if (listDialogResponse.Response == DialogResponse.LeftButton)
         {
             int selectedMapId = (int)listDialogResponse.Item.Tag;
-            IMap selectedMap = MapCollection.GetById(selectedMapId).Value;
+            IMap selectedMap = mapCollection.GetById(selectedMapId).Value;
             ShowConfirmationDialog(player, selectedMap);
         }
     }

--- a/src/Application/Maps/Systems/SetDefaultMapSystem.cs
+++ b/src/Application/Maps/Systems/SetDefaultMapSystem.cs
@@ -4,6 +4,7 @@ public class SetDefaultMapSystem(
     IWorldService worldService,
     IServerService serverService,
     MapInfoService mapInfoService,
+    MapCollection mapCollection,
     TeamPickupService teamPickupService,
     TeamIconService teamIconService,
     MapTextDrawRenderer mapTextDrawRenderer,
@@ -12,7 +13,7 @@ public class SetDefaultMapSystem(
     [Event]
     public void OnGameModeInit()
     {
-        Result<IMap> mapResult = MapCollection.GetByName(serverSettings.MapName);
+        Result<IMap> mapResult = mapCollection.GetByName(serverSettings.MapName);
         if (mapResult.IsSuccess)
         {
             mapInfoService.Load(mapResult.Value);

--- a/tests/Application.Tests/Fakes/FakeMap.cs
+++ b/tests/Application.Tests/Fakes/FakeMap.cs
@@ -1,0 +1,10 @@
+﻿namespace CTF.Application.Tests.Fakes;
+
+public class FakeMap(
+    int id = 0,
+    string name = "RC_Battlefield") : IMap
+{
+    public int Id { get; } = id;
+
+    public string Name { get; } = name;
+}

--- a/tests/Application.Tests/Maps/CurrentMapTests.cs
+++ b/tests/Application.Tests/Maps/CurrentMapTests.cs
@@ -26,7 +26,7 @@ public class CurrentMapTests
     public void Constructor_WhenAlphaTeamLocationsIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> alphaTeamLocations = default;
         List<SpawnLocation> betaTeamLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = FlagLocations.Empty;
@@ -47,7 +47,7 @@ public class CurrentMapTests
     public void Constructor_WhenBetaTeamLocationsIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> betaTeamLocations = default;
         List<SpawnLocation> alphaTeamLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = FlagLocations.Empty;
@@ -68,7 +68,7 @@ public class CurrentMapTests
     public void Constructor_WhenFlagLocationsIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> betaTeamLocations = [SpawnLocation.Empty];
         List<SpawnLocation> alphaTeamLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = default;
@@ -89,7 +89,7 @@ public class CurrentMapTests
     public void Constructor_WhenAlphaTeamLocationsIsEmpty_ShouldThrowArgumentException()
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> alphaTeamLocations = [];
         List<SpawnLocation> betaTeamLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = FlagLocations.Empty;
@@ -110,7 +110,7 @@ public class CurrentMapTests
     public void Constructor_WhenBetaTeamLocationsIsEmpty_ShouldThrowArgumentException()
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> alphaTeamLocations = [SpawnLocation.Empty];
         List<SpawnLocation> betaTeamLocations = [];
         FlagLocations flagLocations = FlagLocations.Empty;
@@ -131,7 +131,7 @@ public class CurrentMapTests
     public void GetMapNameAsText_WhenNameIsObtained_ShouldReturnsValidStringFormat()
     {
         // Arrange
-        IMap map = MapCollection.GetByName("RC_Battlefield").Value;
+        IMap map = new FakeMap(id: 0, name: "RC_Battlefield");
         List<SpawnLocation> spawnLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = FlagLocations.Empty;
         var currentMap = new CurrentMap(map, spawnLocations, spawnLocations, flagLocations);
@@ -149,7 +149,7 @@ public class CurrentMapTests
     public void GetRandomSpawnLocation_WhenTeamIsAlphaOrBeta_ShouldReturnsSpawnLocation(TeamId team)
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> spawnLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = FlagLocations.Empty;
         var currentMap = new CurrentMap(map, spawnLocations, spawnLocations, flagLocations);
@@ -166,7 +166,7 @@ public class CurrentMapTests
     public void GetRandomSpawnLocation_WhenTeamIsNotAlphaOrBeta_ShouldThrowNotSupportedException()
     {
         // Arrange
-        IMap map = MapCollection.GetById(0).Value;
+        IMap map = new FakeMap();
         List<SpawnLocation> spawnLocations = [SpawnLocation.Empty];
         FlagLocations flagLocations = FlagLocations.Empty;
         TeamId team = TeamId.NoTeam;

--- a/tests/Application.Tests/Maps/MapCollectionTests.cs
+++ b/tests/Application.Tests/Maps/MapCollectionTests.cs
@@ -1,8 +1,17 @@
-﻿namespace CTF.Application.Tests.Maps;
+﻿using CTF.Application.Common.Paths;
+
+namespace CTF.Application.Tests.Maps;
 
 public class MapCollectionTests
 {
-    static readonly int[] InvalidMapCases = [-1, 1000, MapCollection.Count];
+    static readonly int[] InvalidMapCases = [-1, 1000];
+    private MapCollection _maps;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _maps = new MapCollection(GameModePaths.Maps);
+    }
 
     [TestCase("de")]
     [TestCase("DE")]
@@ -26,7 +35,7 @@ public class MapCollectionTests
         ];
 
         // Act
-        IEnumerable<IMap> maps = MapCollection.GetAll(findBy);
+        IEnumerable<IMap> maps = _maps.GetAll(findBy);
         string[] actual = maps.Select(map => map.Name).ToArray();
 
         // Assert
@@ -40,9 +49,23 @@ public class MapCollectionTests
         string expectedMessage = Messages.InvalidMap;
 
         // Act
-        Result<IMap> result = MapCollection.GetById(mapId);
+        Result<IMap> result = _maps.GetById(mapId);
 
         // Asserts
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Be(expectedMessage);
+    }
+
+    [Test]
+    public void GetById_WhenMapIdEqualsCount_ShouldReturnsFailureResult()
+    {
+        // Arrange
+        string expectedMessage = Messages.InvalidMap;
+
+        // Act
+        Result<IMap> result = _maps.GetById(_maps.Count);
+
+        // Assert
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().Be(expectedMessage);
     }
@@ -54,10 +77,8 @@ public class MapCollectionTests
     [TestCase(4)]
     public void GetById_WhenMapIdIsValid_ShouldReturnsSuccessResult(int mapId)
     {
-        // Arrange
-
         // Act
-        Result<IMap> result = MapCollection.GetById(mapId);
+        Result<IMap> result = _maps.GetById(mapId);
 
         // Asserts
         result.IsSuccess.Should().BeTrue();
@@ -69,11 +90,11 @@ public class MapCollectionTests
     public void GetByName_WhenMapNameIsNotFound_ShouldReturnsFailureResult()
     {
         // Arrange
-        string mapName = "NotFound"; 
+        string mapName = "NotFound";
         string expectedMessage = Messages.MapNotFound;
 
         // Act
-        Result<IMap> result = MapCollection.GetByName(mapName);
+        Result<IMap> result = _maps.GetByName(mapName);
 
         // Asserts
         result.IsSuccess.Should().BeFalse();
@@ -89,7 +110,7 @@ public class MapCollectionTests
         string expectedMapName = "de_aztec";
 
         // Act
-        Result<IMap> result = MapCollection.GetByName(mapName);
+        Result<IMap> result = _maps.GetByName(mapName);
 
         // Asserts
         result.IsSuccess.Should().BeTrue();
@@ -108,10 +129,10 @@ public class MapCollectionTests
     public void GetNext_WhenMapExists_ShouldReturnsNextMap(int currentId, int expectedId)
     {
         // Arrange
-        IMap current = MapCollection.GetById(currentId).Value;
+        IMap current = _maps.GetById(currentId).Value;
 
         // Act
-        IMap next = MapCollection.GetNext(current);
+        IMap next = _maps.GetNext(current);
 
         // Assert
         next.Id.Should().Be(expectedId);
@@ -121,11 +142,11 @@ public class MapCollectionTests
     public void GetNext_WhenCurrentMapIsLast_ShouldWrapToFirstMap()
     {
         // Arrange
-        IMap lastMap = MapCollection.GetById(MapCollection.Count - 1).Value;
-        IMap firstMap = MapCollection.GetById(0).Value;
+        IMap lastMap = _maps.GetById(_maps.Count - 1).Value;
+        IMap firstMap = _maps.GetById(0).Value;
 
         // Act
-        IMap next = MapCollection.GetNext(lastMap);
+        IMap next = _maps.GetNext(lastMap);
 
         // Assert
         next.Should().Be(firstMap);

--- a/tests/Application.Tests/Maps/MapInfoServiceTests.cs
+++ b/tests/Application.Tests/Maps/MapInfoServiceTests.cs
@@ -1,14 +1,18 @@
-﻿namespace CTF.Application.Tests.Maps;
+﻿using CTF.Application.Common.Paths;
+
+namespace CTF.Application.Tests.Maps;
 
 public class MapInfoServiceTests
 {
+    private static readonly MapCollection s_maps = new(GameModePaths.Maps);
+
     [Test]
     public void Constructor_WhenLoadMethodIsNotInvoked_CurrentMapShouldNotBeNull()
     {
         // Arrange
 
         // Act
-        var service = new MapInfoService();
+        var service = new MapInfoService(s_maps);
         CurrentMap currentMap = service.CurrentMap;
 
         // Assert
@@ -19,7 +23,7 @@ public class MapInfoServiceTests
     public void Load_WhenArgumentIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange
-        var service = new MapInfoService();
+        var service = new MapInfoService(s_maps);
         IMap map = default;
 
         // Act
@@ -35,8 +39,8 @@ public class MapInfoServiceTests
     public void Load_WhenMapIsLoadedFromFileSystem_ShouldCreateInstanceOfTypeCurrentMap(CurrentMap expectedCurrentMap)
     {
         // Arrange
-        var service = new MapInfoService();
-        IMap map = MapCollection.GetById(expectedCurrentMap.Id).Value;
+        var service = new MapInfoService(s_maps);
+        IMap map = s_maps.GetById(expectedCurrentMap.Id).Value;
 
         // Act
         service.Load(map);
@@ -192,7 +196,7 @@ public class MapInfoServiceTests
                 worldTime: 22);
         }
 
-        private static IMap GetMap(string name) => MapCollection.GetByName(name).Value;
+        private static IMap GetMap(string name) => s_maps.GetByName(name).Value;
         IEnumerator IEnumerable.GetEnumerator()
             => this.GetEnumerator();
     }


### PR DESCRIPTION
Remove the global static MapCollection and expose it as a regular service with explicit dependencies.

Changes:
* Convert MapCollection from static to instance-based
* Load map names through constructor injection
* Update MapInfoService to receive MapCollection
* Replace static MapCollection usages throughout the application
* Update unit and integration tests
* Replace implicit global state with explicit dependencies

Benefits:
* Improve testability
* Eliminate hidden dependencies
* Allow different map sources to be configured in the future