### PR TITLE
Refactor flag state management to prevent invalid game states

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -81,8 +81,8 @@ public class MapRotationService(
         string message = Smart.Format(Messages.NextMapWillBeLoadedSoon, new { nextMap.Name });
         worldService.SendClientMessage(Color.Orange, message);
         mapInfoService.Load(nextMap);
-        Team.Alpha.Flag.RemoveCarrier();
-        Team.Beta.Flag.RemoveCarrier();
+        Team.Alpha.Flag.Reset();
+        Team.Beta.Flag.Reset();
         teamPickupService.DestroyAllPickups();
         teamPickupService.CreateFlagFromBasePosition(Team.Alpha);
         teamPickupService.CreateFlagFromBasePosition(Team.Beta);

--- a/src/Application/Players/Accounts/PlayerInfo.cs
+++ b/src/Application/Players/Accounts/PlayerInfo.cs
@@ -183,7 +183,7 @@ public partial class PlayerInfo
             return false;
 
         Flag rivalTeamFlag = Team.RivalTeam.Flag;
-        if(rivalTeamFlag.IsCaptured())
+        if (rivalTeamFlag.HasCarrier)
         {
             Player carrier = rivalTeamFlag.Carrier;
             return carrier.Name.Equals(Name, StringComparison.OrdinalIgnoreCase);

--- a/src/Application/Teams/Flags/Events/OnFlagDropped.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagDropped.cs
@@ -17,7 +17,7 @@ public class OnFlagDropped(
         teamPickupService.CreateFlagFromVector3(team, player.Position);
         teamSoundsService.PlayFlagDroppedSound(team);
         flagAutoReturnTimer.Start(team);
-        team.Flag.RemoveCarrier();
+        team.Flag.Drop();
         var message = Smart.Format(Messages.OnFlagDropped, new
         {
             PlayerName = player.Name,

--- a/src/Application/Teams/Flags/Flag.cs
+++ b/src/Application/Teams/Flags/Flag.cs
@@ -7,6 +7,8 @@ public class Flag
     public required string Name { get; init; } = string.Empty;
     public required Color ColorHex { get; init; }
 
+    public FlagStatus Status { get; private set; } = FlagStatus.BasePosition;
+
     /// <summary>
     /// Represents the player that holds the flag.
     /// </summary>
@@ -18,7 +20,7 @@ public class Flag
     /// <summary>
     /// Checks if the flag has been captured by a player.
     /// </summary>
-    public bool IsCaptured() => Carrier is not null;
+    public bool HasCarrier => Carrier is not null;
 
     /// <summary>
     /// Gets the name of the player who captured the flag.
@@ -26,14 +28,68 @@ public class Flag
     /// <remarks>
     /// If the flag is not captured, returns <c>None</c>.
     /// </remarks>
-    public string CarrierName => IsCaptured() ? Carrier.Name : "None";
+    public string CarrierName => HasCarrier ? Carrier.Name : "None";
+
+    /// <summary>
+    /// Marks the flag as captured by the specified player.
+    /// </summary>
+    /// <param name="player">
+    /// The player who captured the flag.
+    /// </param>
+    public void Capture(Player player)
+    {
+        ArgumentNullException.ThrowIfNull(player);
+        RemoveCarrier();
+        SetCarrier(player);
+        Status = FlagStatus.Captured;
+    }
+
+    /// <summary>
+    /// Marks the flag as taken from a dropped state by the specified player.
+    /// </summary>
+    /// <param name="player">
+    /// The player who picked up the flag.
+    /// </param>
+    public void Take(Player player)
+    {
+        ArgumentNullException.ThrowIfNull(player);
+        RemoveCarrier();
+        SetCarrier(player);
+        Status = FlagStatus.Taken;
+    }
+
+    /// <summary>
+    /// Drops the flag and removes its current carrier.
+    /// </summary>
+    public void Drop()
+    {
+        RemoveCarrier();
+        Status = FlagStatus.Dropped;
+    }
+
+    /// <summary>
+    /// Returns the flag to its base state and removes its current carrier.
+    /// </summary>
+    public void ReturnToBase()
+    {
+        RemoveCarrier();
+        Status = FlagStatus.BasePosition;
+    }
+
+    /// <summary>
+    /// Resets the flag to its initial state.
+    /// </summary>
+    public void Reset()
+    {
+        RemoveCarrier();
+        Status = FlagStatus.BasePosition;
+    }
 
     /// <summary>
     /// Sets the player who holds the flag.
     /// </summary>
-    public void SetCarrier(Player player)
+    private void SetCarrier(Player player)
     {
-        ArgumentNullException.ThrowIfNull(player);
         Carrier = player;
         player.SetAttachedObject(
             index: 0, 
@@ -43,13 +99,14 @@ public class Flag
             rotation: new Vector3(171.500030f, 66.200012f, -4.100002f), 
             scale: new Vector3(1.0f, 1.0f, 1.0f), 
             materialColor1: ColorHex,
-            materialColor2: ColorHex);
+            materialColor2: ColorHex
+        );
     }
 
     /// <summary>
     /// Removes the flag that the player is holding.
     /// </summary>
-    public void RemoveCarrier()
+    private void RemoveCarrier()
     {
         if (Carrier is not null)
         {

--- a/src/Application/Teams/Flags/FlagAutoReturnTimer.cs
+++ b/src/Application/Teams/Flags/FlagAutoReturnTimer.cs
@@ -20,7 +20,7 @@ public class FlagAutoReturnTimer(
             teamPickupService.CreateFlagFromBasePosition(team);
             teamPickupService.DestroyExteriorMarker(team);
             teamSoundsService.PlayFlagReturnedSound(team);
-            team.IsFlagAtBasePosition = true;
+            team.Flag.ReturnToBase();
             var message = Smart.Format(Messages.FlagAutoReturn, new
             {
                 Seconds = flagAutoReturnSettings.Delay,

--- a/src/Application/Teams/Flags/Systems/FlagCarrierPauseHandler.cs
+++ b/src/Application/Teams/Flags/Systems/FlagCarrierPauseHandler.cs
@@ -56,8 +56,7 @@ public class FlagCarrierPauseHandler(
                 return;
 
             Team rivalTeam = playerInfo.Team.RivalTeam;
-            rivalTeam.IsFlagAtBasePosition = true;
-            rivalTeam.Flag.RemoveCarrier();
+            rivalTeam.Flag.ReturnToBase();
             player.HideOnRadarMap();
             teamPickupService.CreateFlagFromBasePosition(rivalTeam);
             teamPickupService.DestroyExteriorMarker(rivalTeam);

--- a/src/Application/Teams/Flags/Systems/ResetFlagSystem.cs
+++ b/src/Application/Teams/Flags/Systems/ResetFlagSystem.cs
@@ -37,9 +37,8 @@ public class ResetFlagSystem(
             PlayerName = player.Name,
             team.ColorName
         });
-        team.IsFlagAtBasePosition = true;
         team.Flag.Carrier?.HideOnRadarMap();
-        team.Flag.RemoveCarrier();
+        team.Flag.ReturnToBase();
         teamPickupService.CreateFlagFromBasePosition(team);
         teamPickupService.DestroyExteriorMarker(team);
         teamSoundsService.PlayFlagReturnedSound(team);

--- a/src/Application/Teams/Team.cs
+++ b/src/Application/Teams/Team.cs
@@ -77,8 +77,6 @@ public class Team
     public Team RivalTeam { get; private set; }
     public TeamMembers Members { get; } = [];
     public TeamStatsPerRound StatsPerRound { get; } = new();
-    public bool IsFlagAtBasePosition { get; set; } = true;
-
     public virtual string GetMembersAsText() => $"{Members.Count}";
     public virtual string GetScoreAsText() => $"{Name}: {StatsPerRound.Score}";
     public virtual bool IsFull() => Members.Count > RivalTeam.Members.Count;
@@ -87,8 +85,7 @@ public class Team
     {
         StatsPerRound.Reset();
         Members.Clear();
-        Flag.RemoveCarrier();
-        IsFlagAtBasePosition = true;
+        Flag.Reset();
     }
 
     public virtual string GetAvailabilityMessage(bool entireMessage = true)
@@ -111,19 +108,17 @@ public class Team
     public virtual FlagStatus HandleFlagInteraction(Player flagPicker)
     {
         ArgumentNullException.ThrowIfNull(flagPicker);
-        if (IsFlagAtBasePosition)
+        if (Flag.Status == FlagStatus.BasePosition)
         {
             if (flagPicker.Team == (int)RivalTeam.Id)
             {
-                IsFlagAtBasePosition = false;
-                Flag.SetCarrier(flagPicker);
+                Flag.Capture(flagPicker);
                 return FlagStatus.Captured;
             }
 
             if (flagPicker == RivalTeam.Flag.Carrier)
             {
-                RivalTeam.IsFlagAtBasePosition = true;
-                RivalTeam.Flag.RemoveCarrier();
+                RivalTeam.Flag.ReturnToBase();
                 StatsPerRound.AddScore();
                 return FlagStatus.Brought;
             }
@@ -133,12 +128,11 @@ public class Team
 
         if (flagPicker.Team == (int)Id)
         {
-            IsFlagAtBasePosition = true;
+            Flag.ReturnToBase();
             return FlagStatus.Returned;
         }
 
-        IsFlagAtBasePosition = false;
-        Flag.SetCarrier(flagPicker);
+        Flag.Take(flagPicker);
         return FlagStatus.Taken;
     }
 
@@ -155,8 +149,7 @@ public class Team
         {
             StatsPerRound.Reset();
             Members.Clear();
-            Flag.RemoveCarrier();
-            IsFlagAtBasePosition = true;
+            Flag.Reset();
         }
     }
 }

--- a/tests/Application.Tests/Players/Accounts/HasCapturedFlagTests.cs
+++ b/tests/Application.Tests/Players/Accounts/HasCapturedFlagTests.cs
@@ -36,7 +36,7 @@ public class HasCapturedFlagTests
         var player = new PlayerInfo();
         player.SetTeam(TeamId.Alpha);
         player.SetName("Bob");
-        betaTeam.Flag.SetCarrier(alphaTeamPlayer);
+        betaTeam.Flag.Capture(alphaTeamPlayer);
 
         // Act
         bool actual = player.HasCapturedFlag();
@@ -56,7 +56,7 @@ public class HasCapturedFlagTests
         var player = new PlayerInfo();
         player.SetTeam(TeamId.Beta);
         player.SetName("Bob");
-        alphaTeam.Flag.SetCarrier(betaTeamPlayer);
+        alphaTeam.Flag.Capture(betaTeamPlayer);
 
         // Act
         bool actual = player.HasCapturedFlag();
@@ -75,7 +75,7 @@ public class HasCapturedFlagTests
         var player = new PlayerInfo();
         player.SetTeam(TeamId.Alpha);
         player.SetName(alphaTeamPlayer1.Name);
-        betaTeam.Flag.SetCarrier(alphaTeamPlayer2);
+        betaTeam.Flag.Capture(alphaTeamPlayer2);
 
         // Act
         bool actual = player.HasCapturedFlag();
@@ -94,7 +94,7 @@ public class HasCapturedFlagTests
         var player = new PlayerInfo();
         player.SetTeam(TeamId.Beta);
         player.SetName(betaTeamPlayer1.Name);
-        alphaTeam.Flag.SetCarrier(betaTeamPlayer2);
+        alphaTeam.Flag.Capture(betaTeamPlayer2);
 
         // Act
         bool actual = player.HasCapturedFlag();
@@ -112,7 +112,6 @@ public class HasCapturedFlagTests
         var player = new PlayerInfo();
         player.SetTeam(TeamId.Beta);
         player.SetName(betaTeamPlayer.Name);
-        alphaTeam.Flag.RemoveCarrier();
 
         // Act
         bool actual = player.HasCapturedFlag();
@@ -130,7 +129,6 @@ public class HasCapturedFlagTests
         var player = new PlayerInfo();
         player.SetTeam(TeamId.Alpha);
         player.SetName(alphaTeamPlayer.Name);
-        betaTeam.Flag.RemoveCarrier();
 
         // Act
         bool actual = player.HasCapturedFlag();

--- a/tests/Application.Tests/Teams/Flags/FlagTests.cs
+++ b/tests/Application.Tests/Teams/Flags/FlagTests.cs
@@ -3,59 +3,43 @@
 public class FlagTests
 {
     [Test]
-    public void IsCaptured_WhenFlagIsCapturedByPlayer_ShouldReturnsTrue()
+    public void HasCarrier_WhenFlagHasCarrier_ShouldReturnsTrue()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Red,
-            Icon = FlagIcon.Red,
-            Name = "Red",
-            ColorHex = Color.Red
-        };
+        var flag = CreateFlag();
         var fakeCarrier = new FakeCarrier();
-        flag.SetCarrier(fakeCarrier);
+
+        flag.Capture(fakeCarrier);
 
         // Act
-        bool actual = flag.IsCaptured();
+        bool actual = flag.HasCarrier;
 
         // Assert
         actual.Should().BeTrue();
     }
 
     [Test]
-    public void IsCaptured_WhenFlagIsNotCapturedByPlayer_ShouldReturnsFalse()
+    public void HasCarrier_WhenFlagHasNoCarrier_ShouldReturnsFalse()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Red,
-            Icon = FlagIcon.Red,
-            Name = "Red",
-            ColorHex = Color.Red
-        };
+        var flag = CreateFlag();
 
         // Act
-        bool actual = flag.IsCaptured();
+        bool actual = flag.HasCarrier;
 
         // Assert
         actual.Should().BeFalse();
     }
 
     [Test]
-    public void CarrierName_WhenFlagIsCaptured_ShouldReturnsCarrierName()
+    public void CarrierName_WhenFlagHasCarrier_ShouldReturnsCarrierName()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Blue,
-            Icon = FlagIcon.Blue,
-            Name = "Blue",
-            ColorHex = Color.Blue
-        };
+        var flag = CreateFlag();
         var expectedCarrierName = "Bob";
         var fakeCarrier = new FakePlayer(id: 1, expectedCarrierName);
-        flag.SetCarrier(fakeCarrier);
+
+        flag.Capture(fakeCarrier);
 
         // Act
         string actual = flag.CarrierName;
@@ -65,16 +49,10 @@ public class FlagTests
     }
 
     [Test]
-    public void CarrierName_WhenFlagIsNotCaptured_ShouldReturnsNone()
+    public void CarrierName_WhenFlagHasNoCarrier_ShouldReturnsNone()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Blue,
-            Icon = FlagIcon.Blue,
-            Name = "Blue",
-            ColorHex = Color.Blue
-        };
+        var flag = CreateFlag();
         var expectedCarrierName = "None";
 
         // Act
@@ -85,20 +63,14 @@ public class FlagTests
     }
 
     [Test]
-    public void SetCarrier_WhenArgumentIsNull_ShouldThrowArgumentNullException()
+    public void Capture_WhenArgumentIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Red,
-            Icon = FlagIcon.Red,
-            Name = "Red",
-            ColorHex = Color.Red
-        };
+        var flag = CreateFlag();
         Player player = default;
 
         // Act
-        Action act = () => flag.SetCarrier(player);
+        Action act = () => flag.Capture(player);
 
         // Assert
         act.Should()
@@ -107,62 +79,266 @@ public class FlagTests
     }
 
     [Test]
-    public void SetCarrier_WhenArgumentIsValid_ShouldSetPlayerAsCarrier()
+    public void Capture_WhenArgumentIsValid_ShouldSetPlayerAsCarrier()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Red,
-            Icon = FlagIcon.Red,
-            Name = "Red",
-            ColorHex = Color.Red
-        };
+        var flag = CreateFlag();
         var fakeCarrier = new FakeCarrier();
 
         // Act
-        flag.SetCarrier(fakeCarrier);
+        flag.Capture(fakeCarrier);
 
         // Assert
         flag.Carrier.Should().Be(fakeCarrier);
     }
 
     [Test]
-    public void RemoveCarrier_WhenNoPlayerHasCapturedFlag_ShouldNotThrowNullReferenceException()
+    public void Capture_WhenArgumentIsValid_ShouldSetStatusAsCaptured()
     {
         // Arrange
-        var flag = new Flag
-        {
-            Model = FlagModel.Red,
-            Icon = FlagIcon.Red,
-            Name = "Red",
-            ColorHex = Color.Red
-        };
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
 
         // Act
-        Action act = flag.RemoveCarrier;
+        flag.Capture(fakeCarrier);
+
+        // Assert
+        flag.Status.Should().Be(FlagStatus.Captured);
+    }
+
+    [Test]
+    public void Capture_WhenFlagAlreadyHasCarrier_ShouldReplaceCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var player1 = new FakeCarrier();
+        var player2 = new FakeCarrier();
+
+        flag.Capture(player1);
+
+        // Act
+        flag.Capture(player2);
+
+        // Assert
+        flag.Carrier.Should().Be(player2);
+        flag.Status.Should().Be(FlagStatus.Captured);
+    }
+
+    [Test]
+    public void Capture_WhenFlagWasReturnedToBase_ShouldSetNewCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var player1 = new FakeCarrier();
+        var player2 = new FakeCarrier();
+
+        flag.Capture(player1);
+        flag.ReturnToBase();
+
+        // Act
+        flag.Capture(player2);
+
+        // Assert
+        flag.Carrier.Should().Be(player2);
+        flag.Status.Should().Be(FlagStatus.Captured);
+    }
+
+    [Test]
+    public void Take_WhenArgumentIsNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        Player player = default;
+
+        // Act
+        Action act = () => flag.Take(player);
+
+        // Assert
+        act.Should()
+           .Throw<ArgumentNullException>()
+           .WithParameterName(nameof(player));
+    }
+
+    [Test]
+    public void Take_WhenArgumentIsValid_ShouldSetPlayerAsCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        // Act
+        flag.Take(fakeCarrier);
+
+        // Assert
+        flag.Carrier.Should().Be(fakeCarrier);
+    }
+
+    [Test]
+    public void Take_WhenArgumentIsValid_ShouldSetStatusAsTaken()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        // Act
+        flag.Take(fakeCarrier);
+
+        // Assert
+        flag.Status.Should().Be(FlagStatus.Taken);
+    }
+
+    [Test]
+    public void Take_WhenFlagAlreadyHasCarrier_ShouldReplaceCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var player1 = new FakeCarrier();
+        var player2 = new FakeCarrier();
+
+        flag.Take(player1);
+
+        // Act
+        flag.Take(player2);
+
+        // Assert
+        flag.Carrier.Should().Be(player2);
+        flag.Status.Should().Be(FlagStatus.Taken);
+    }
+
+    [Test]
+    public void Take_WhenFlagWasDropped_ShouldSetNewCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var player1 = new FakeCarrier();
+        var player2 = new FakeCarrier();
+
+        flag.Capture(player1);
+        flag.Drop();
+
+        // Act
+        flag.Take(player2);
+
+        // Assert
+        flag.Carrier.Should().Be(player2);
+        flag.Status.Should().Be(FlagStatus.Taken);
+    }
+
+    [Test]
+    public void Drop_WhenFlagHasCarrier_ShouldRemoveCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        flag.Capture(fakeCarrier);
+
+        // Act
+        flag.Drop();
+
+        // Assert
+        flag.Carrier.Should().BeNull();
+    }
+
+    [Test]
+    public void Drop_WhenCalled_ShouldSetStatusAsDropped()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        flag.Capture(fakeCarrier);
+
+        // Act
+        flag.Drop();
+
+        // Assert
+        flag.Status.Should().Be(FlagStatus.Dropped);
+    }
+
+    [Test]
+    public void Drop_WhenFlagHasNoCarrier_ShouldNotThrowNullReferenceException()
+    {
+        // Arrange
+        var flag = CreateFlag();
+
+        // Act
+        Action act = flag.Drop;
 
         // Assert
         act.Should().NotThrow<NullReferenceException>();
     }
 
     [Test]
-    public void RemoveCarrier_WhenPlayerHasCapturedFlag_ShouldRemoveFlagOfThatPlayer()
+    public void ReturnToBase_WhenFlagHasCarrier_ShouldRemoveCarrier()
     {
         // Arrange
-        var flag = new Flag
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        flag.Capture(fakeCarrier);
+
+        // Act
+        flag.ReturnToBase();
+
+        // Assert
+        flag.Carrier.Should().BeNull();
+    }
+
+    [Test]
+    public void ReturnToBase_WhenCalled_ShouldSetStatusAsBasePosition()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        flag.Capture(fakeCarrier);
+
+        // Act
+        flag.ReturnToBase();
+
+        // Assert
+        flag.Status.Should().Be(FlagStatus.BasePosition);
+    }
+
+    [Test]
+    public void Reset_WhenFlagHasCarrier_ShouldRemoveCarrier()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        flag.Capture(fakeCarrier);
+
+        // Act
+        flag.Reset();
+
+        // Assert
+        flag.Carrier.Should().BeNull();
+    }
+
+    [Test]
+    public void Reset_WhenCalled_ShouldSetStatusAsBasePosition()
+    {
+        // Arrange
+        var flag = CreateFlag();
+        var fakeCarrier = new FakeCarrier();
+
+        flag.Capture(fakeCarrier);
+
+        // Act
+        flag.Reset();
+
+        // Assert
+        flag.Status.Should().Be(FlagStatus.BasePosition);
+    }
+
+    private static Flag CreateFlag() =>
+        new()
         {
             Model = FlagModel.Red,
             Icon = FlagIcon.Red,
             Name = "Red",
             ColorHex = Color.Red
         };
-        var fakeCarrier = new FakeCarrier();
-        flag.SetCarrier(fakeCarrier);
-
-        // Act
-        flag.RemoveCarrier();
-
-        // Assert
-        flag.Carrier.Should().BeNull();
-    }
 }

--- a/tests/Application.Tests/Teams/HandleFlagInteractionTests.cs
+++ b/tests/Application.Tests/Teams/HandleFlagInteractionTests.cs
@@ -37,7 +37,7 @@ public class HandleFlagInteractionTests
 
         // Asserts
         actual.Should().Be(expectedStatus);
-        betaTeam.IsFlagAtBasePosition.Should().BeFalse();
+        betaTeam.Flag.Status.Should().Be(expectedStatus);
         betaTeam.Flag.Carrier.Should().Be(alphaTeamPlayer);
     }
 
@@ -55,7 +55,7 @@ public class HandleFlagInteractionTests
 
         // Asserts
         actual.Should().Be(expectedStatus);
-        alphaTeam.IsFlagAtBasePosition.Should().BeFalse();
+        alphaTeam.Flag.Status.Should().Be(expectedStatus);
         alphaTeam.Flag.Carrier.Should().Be(betaTeamPlayer);
     }
 
@@ -68,7 +68,7 @@ public class HandleFlagInteractionTests
         var alphaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: alphaTeam.Id);
         var expectedStatus = FlagStatus.Brought;
         int expectedScore = 1;
-        betaTeam.Flag.SetCarrier(alphaTeamPlayer);
+        betaTeam.Flag.Capture(alphaTeamPlayer);
 
         // Act
         FlagStatus actual = alphaTeam.HandleFlagInteraction(flagPicker: alphaTeamPlayer);
@@ -76,7 +76,7 @@ public class HandleFlagInteractionTests
         // Asserts
         actual.Should().Be(expectedStatus);
         betaTeam.Flag.Carrier.Should().BeNull();
-        betaTeam.IsFlagAtBasePosition.Should().BeTrue();
+        betaTeam.Flag.Status.Should().Be(FlagStatus.BasePosition);
         alphaTeam.StatsPerRound.Score.Should().Be(expectedScore);
     }
 
@@ -89,7 +89,7 @@ public class HandleFlagInteractionTests
         var betaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: betaTeam.Id);
         var expectedStatus = FlagStatus.Brought;
         int expectedScore = 1;
-        alphaTeam.Flag.SetCarrier(betaTeamPlayer);
+        alphaTeam.Flag.Capture(betaTeamPlayer);
 
         // Act
         FlagStatus actual = betaTeam.HandleFlagInteraction(flagPicker: betaTeamPlayer);
@@ -97,7 +97,7 @@ public class HandleFlagInteractionTests
         // Asserts
         actual.Should().Be(expectedStatus);
         alphaTeam.Flag.Carrier.Should().BeNull();
-        alphaTeam.IsFlagAtBasePosition.Should().BeTrue();
+        alphaTeam.Flag.Status.Should().Be(FlagStatus.BasePosition);
         betaTeam.StatsPerRound.Score.Should().Be(expectedScore);
     }
 
@@ -115,7 +115,7 @@ public class HandleFlagInteractionTests
         // Asserts
         actual.Should().Be(expectedStatus);
         alphaTeam.Flag.Carrier.Should().BeNull();
-        alphaTeam.IsFlagAtBasePosition.Should().BeTrue();
+        alphaTeam.Flag.Status.Should().Be(expectedStatus);
     }
 
     [Test]
@@ -132,7 +132,7 @@ public class HandleFlagInteractionTests
         // Asserts
         actual.Should().Be(expectedStatus);
         betaTeam.Flag.Carrier.Should().BeNull();
-        betaTeam.IsFlagAtBasePosition.Should().BeTrue();
+        betaTeam.Flag.Status.Should().Be(expectedStatus);
     }
 
     [Test]
@@ -142,14 +142,14 @@ public class HandleFlagInteractionTests
         Team alphaTeam = Team.Alpha;
         var alphaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: alphaTeam.Id);
         var expectedStatus = FlagStatus.Returned;
-        alphaTeam.IsFlagAtBasePosition = false;
+        alphaTeam.Flag.Drop();
 
         // Act
         FlagStatus actual = alphaTeam.HandleFlagInteraction(flagPicker: alphaTeamPlayer);
 
         // Asserts
         actual.Should().Be(expectedStatus);
-        alphaTeam.IsFlagAtBasePosition.Should().BeTrue();
+        alphaTeam.Flag.Status.Should().Be(FlagStatus.BasePosition);
         alphaTeam.Flag.Carrier.Should().BeNull();
     }
 
@@ -160,14 +160,14 @@ public class HandleFlagInteractionTests
         Team betaTeam = Team.Beta;
         var betaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: betaTeam.Id);
         var expectedStatus = FlagStatus.Returned;
-        betaTeam.IsFlagAtBasePosition = false;
+        betaTeam.Flag.Drop();
 
         // Act
         FlagStatus actual = betaTeam.HandleFlagInteraction(flagPicker: betaTeamPlayer);
 
         // Asserts
         actual.Should().Be(expectedStatus);
-        betaTeam.IsFlagAtBasePosition.Should().BeTrue();
+        betaTeam.Flag.Status.Should().Be(FlagStatus.BasePosition);
         betaTeam.Flag.Carrier.Should().BeNull();
     }
 
@@ -179,14 +179,14 @@ public class HandleFlagInteractionTests
         Team betaTeam = Team.Beta;
         var betaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: betaTeam.Id);
         var expectedStatus = FlagStatus.Taken;
-        alphaTeam.IsFlagAtBasePosition = false;
+        alphaTeam.Flag.Drop();
 
         // Act
         FlagStatus actual = alphaTeam.HandleFlagInteraction(flagPicker: betaTeamPlayer);
 
         // Asserts
         actual.Should().Be(expectedStatus);
-        alphaTeam.IsFlagAtBasePosition.Should().BeFalse();
+        alphaTeam.Flag.Status.Should().Be(expectedStatus);
         alphaTeam.Flag.Carrier.Should().Be(betaTeamPlayer);
     }
 
@@ -198,14 +198,14 @@ public class HandleFlagInteractionTests
         Team betaTeam = Team.Beta;
         var alphaTeamPlayer = new FakePlayer(id: 1, name: "Bob", team: alphaTeam.Id);
         var expectedStatus = FlagStatus.Taken;
-        betaTeam.IsFlagAtBasePosition = false;
+        betaTeam.Flag.Drop();
 
         // Act
         FlagStatus actual = betaTeam.HandleFlagInteraction(flagPicker: alphaTeamPlayer);
 
         // Asserts
         actual.Should().Be(expectedStatus);
-        betaTeam.IsFlagAtBasePosition.Should().BeFalse();
+        betaTeam.Flag.Status.Should().Be(expectedStatus);
         betaTeam.Flag.Carrier.Should().Be(alphaTeamPlayer);
     }
 }


### PR DESCRIPTION
## Summary

This refactor prevents invalid flag states by making Flag the single source of truth for flag state transitions.

Previously, flag state was distributed across both `Team.IsFlagAtBasePosition` and the carrier management methods (`Flag.SetCarrier` / `Flag.RemoveCarrier`).

Because these values were updated independently, it was possible to accidentally introduce inconsistent states such as:

* `IsFlagAtBasePosition = true` and `Carrier != null`
* `IsFlagAtBasePosition = false` and `Carrier == null`

This refactor centralizes flag state transitions within `Flag` through explicit domain operations (`Capture`, `Take`, `Drop`, `ReturnToBase`, and `Reset`), making `Flag` the single source of truth and preventing invalid state combinations.

Additional changes:

* Removed `IsFlagAtBasePosition`.
* Added `Flag.Status` as the source of truth for flag state.
* Made `SetCarrier` and `RemoveCarrier` implementation details.
* Renamed `IsCaptured` to `HasCarrier` for better semantic accuracy.
* Updated and expanded test coverage to validate the new behavior and state transitions.

The goal of this refactor is to improve consistency, reduce the risk of invalid states, and make the domain model more expressive.
