### PR TITLE
refactor: add defensive checks for weapon catalog changes

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1222,11 +1222,29 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The weapon catalog has changed. Please open the weapon list again..
+        /// </summary>
+        internal static string WeaponCatalogChanged {
+            get {
+                return ResourceManager.GetString("WeaponCatalogChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Press Y to show the available weapons.
         /// </summary>
         internal static string WeaponListUsage {
             get {
                 return ResourceManager.GetString("WeaponListUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This weapon is no longer available..
+        /// </summary>
+        internal static string WeaponNoLongerAvailable {
+            get {
+                return ResourceManager.GetString("WeaponNoLongerAvailable", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -504,8 +504,14 @@
   <data name="WeaponAlreadyExists" xml:space="preserve">
     <value>{Name} is already in the weapon package</value>
   </data>
+  <data name="WeaponCatalogChanged" xml:space="preserve">
+    <value>The weapon catalog has changed. Please open the weapon list again.</value>
+  </data>
   <data name="WeaponListUsage" xml:space="preserve">
     <value>Press Y to show the available weapons</value>
+  </data>
+  <data name="WeaponNoLongerAvailable" xml:space="preserve">
+    <value>This weapon is no longer available.</value>
   </data>
   <data name="WeaponNotFound" xml:space="preserve">
     <value>Weapon has not been found</value>

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -79,7 +79,14 @@ public class WeaponSystem : ISystem
         if (response.IsRightButtonOrDisconnected())
             return;
 
-        IWeapon weaponSelectedFromDialog = _weaponCatalog.GetByIndex(response.ItemIndex).Value;
+        Result<IWeapon> weaponResult = _weaponCatalog.GetByIndex(response.ItemIndex);
+        if (weaponResult.IsFailed)
+        {
+            player.SendClientMessage(Color.Red, Messages.WeaponCatalogChanged);
+            return;
+        }
+
+        IWeapon weaponSelectedFromDialog = weaponResult.Value;
         if (selectedWeapons.Exists(weaponSelectedFromDialog))
         {
             var message = Smart.Format(Messages.WeaponAlreadyExists, weaponSelectedFromDialog);
@@ -115,7 +122,14 @@ public class WeaponSystem : ISystem
         if (response.IsRightButtonOrDisconnected())
             return;
 
-        IWeapon weaponSelectedFromDialog = _weaponCatalog.GetByName(response.Item.Text).Value;
+        Result<IWeapon> weaponResult = _weaponCatalog.GetByName(response.Item.Text);
+        if (weaponResult.IsFailed)
+        {
+            player.SendClientMessage(Color.Red, Messages.WeaponNoLongerAvailable);
+            return;
+        }
+
+        IWeapon weaponSelectedFromDialog = weaponResult.Value;
         var message = Smart.Format(Messages.WeaponSuccessfullyRemoved, weaponSelectedFromDialog);
         player.SendClientMessage(Color.Red, message);
         selectedWeapons.Remove(weaponSelectedFromDialog);


### PR DESCRIPTION
Prevent weapon selection dialogs from failing when the active weapon catalog changes while a player is interacting with it.

For example, a player may open the weapon list, an administrator switches the active catalog, and the player then selects a weapon that no longer exists in the current catalog. Instead of throwing an exception, the player now receives a friendly error message.