### PR TITLE
feat: add support for runtime weapon catalog switching

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1222,11 +1222,29 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This weapon catalog is now active..
+        /// </summary>
+        internal static string WeaponCatalogAlreadyActive {
+            get {
+                return ResourceManager.GetString("WeaponCatalogAlreadyActive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The weapon catalog has changed. Please open the weapon list again..
         /// </summary>
         internal static string WeaponCatalogChanged {
             get {
                 return ResourceManager.GetString("WeaponCatalogChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The weapon catalog has been changed to &apos;{Type} Weapons&apos;..
+        /// </summary>
+        internal static string WeaponCatalogChangedTo {
+            get {
+                return ResourceManager.GetString("WeaponCatalogChangedTo", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -504,8 +504,14 @@
   <data name="WeaponAlreadyExists" xml:space="preserve">
     <value>{Name} is already in the weapon package</value>
   </data>
+  <data name="WeaponCatalogAlreadyActive" xml:space="preserve">
+    <value>This weapon catalog is now active.</value>
+  </data>
   <data name="WeaponCatalogChanged" xml:space="preserve">
     <value>The weapon catalog has changed. Please open the weapon list again.</value>
+  </data>
+  <data name="WeaponCatalogChangedTo" xml:space="preserve">
+    <value>The weapon catalog has been changed to '{Type} Weapons'.</value>
   </data>
   <data name="WeaponListUsage" xml:space="preserve">
     <value>Press Y to show the available weapons</value>

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
@@ -19,7 +19,7 @@ namespace CTF.Application.Players.GeneralCommands.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DetailedCommandInfo {
@@ -65,9 +65,9 @@ namespace CTF.Application.Players.GeneralCommands.Resources {
         ///{Color1}/settotalkills: {Color2}Sets the total kills to a specific player.
         ///{Color1}/setscore: {Color2}Sets the score of a player to a specified value.
         ///{Color1}/addscore: {Color2}Increases the player&apos;s score by a designated amount.
+        ///{Color1}/weaponcatalog: {Color2}Allows you to change the current active weapon catalog.
         ///{Color1}/addallscore: {Color2}Increases the score of all players by a specified amount.
-        ///{Color1}/addcoins: {Color2}Increases the player&apos;s coins by a designated amount.
-        ///{Color1}/addallcoins: {Color2}Grant a set nu [rest of string was truncated]&quot;;.
+        ///{Color1}/addcoins: {Color2}Increases [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Admin {
             get {
@@ -79,14 +79,14 @@ namespace CTF.Application.Players.GeneralCommands.Resources {
         ///   Looks up a localized string similar to {Color1}Capture The Flag is an open source project. 
         ///{Color1}Check out its official repository: 
         ///{Color2}https://github.com/DevD4v3/Capture-The-Flag
-        ///{Color1}Creator and programmer: {Color2}DevD4v3 (Dave Roman)
+        ///{Color1}Creator and programmer: {Color2}DevD4v3 (David Roman)
         ///{Color1}Mappers:{Color2} 
         ///DragonZafiro, Elorreli, amirab, JamesT85,
         ///TheYoungCapone, B4MB1[MC], iMaster, mihaibr,
         ///UnuAlex, SpikY_, Niktia_Ruchkov, Amads, denis_32,
         ///Samarchai, haubitze, Ghost-X, Zniper, Dr.Pawno,
         ///SENiOR, saawan, Risq, Famous, Leo and Pyraeus.
-        ///{Color1}Acknowledgments to:{Color2 [rest of string was truncated]&quot;;.
+        ///{Color1}Acknowledgments to:{Color [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Credits {
             get {

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
@@ -122,6 +122,7 @@
 {Color1}/settotalkills: {Color2}Sets the total kills to a specific player.
 {Color1}/setscore: {Color2}Sets the score of a player to a specified value.
 {Color1}/addscore: {Color2}Increases the player's score by a designated amount.
+{Color1}/weaponcatalog: {Color2}Allows you to change the current active weapon catalog.
 {Color1}/addallscore: {Color2}Increases the score of all players by a specified amount.
 {Color1}/addcoins: {Color2}Increases the player's coins by a designated amount.
 {Color1}/addallcoins: {Color2}Grant a set number of coins to all players.
@@ -140,7 +141,7 @@
     <value>{Color1}Capture The Flag is an open source project. 
 {Color1}Check out its official repository: 
 {Color2}https://github.com/DevD4v3/Capture-The-Flag
-{Color1}Creator and programmer: {Color2}DevD4v3 (Dave Roman)
+{Color1}Creator and programmer: {Color2}DevD4v3 (David Roman)
 {Color1}Mappers:{Color2} 
 DragonZafiro, Elorreli, amirab, JamesT85,
 TheYoungCapone, B4MB1[MC], iMaster, mihaibr,
@@ -197,7 +198,7 @@ Beware! Enemies will see flag carriers on their radar as well!</value>
 {Color1}/changename: {Color2}Change your account name.
 {Color1}/skin: {Color2}Change your character's skin.
 {Color1}/weapons: {Color2}Display a list of available weapons
-{Color1}/pack: {Color2}Display your current weapons package.
+{Color1}/weaponpack: {Color2}Display your current weapons package.
 {Color1}/combos: {Color2}Display a list of available combos and their benefits.
 {Color1}/scoreboard: {Color2}Show the current scoreboard with player scores.
 

--- a/src/Application/Players/Weapons/Catalogs/WeaponCatalogBase.cs
+++ b/src/Application/Players/Weapons/Catalogs/WeaponCatalogBase.cs
@@ -46,6 +46,11 @@ public abstract class WeaponCatalogBase
     public IReadOnlyList<IWeapon> GetAll() => _weapons;
 
     /// <summary>
+    /// Determines whether the specified weapon belongs to this catalog.
+    /// </summary>
+    public bool Contains(IWeapon weapon) => _weapons.Exists(w => w.Id == weapon.Id);
+
+    /// <summary>
     /// Gets a weapon by its identifier.
     /// </summary>
     public Result<IWeapon> GetById(Weapon id)

--- a/src/Application/Players/Weapons/Catalogs/WeaponCatalogSettings.cs
+++ b/src/Application/Players/Weapons/Catalogs/WeaponCatalogSettings.cs
@@ -1,20 +1,40 @@
 ﻿namespace CTF.Application.Players.Weapons.Catalogs;
 
 /// <summary>
-/// Stores the active weapon catalog configuration.
+/// Represents the weapon catalog configuration currently used by the server.
+/// The active catalog can be changed at runtime.
 /// </summary>
 public class WeaponCatalogSettings
 {
     /// <summary>
     /// Gets or sets the catalog currently used by the server.
     /// </summary>
-    public WeaponCatalogType Type { get; }
+    public WeaponCatalogType Type { get; private set; }
 
     public WeaponCatalogSettings(WeaponCatalogType type = WeaponCatalogType.Walking)
     {
-        if (!Enum.IsDefined(type))
-            throw new ArgumentOutOfRangeException(nameof(type), type, "The weapon catalog type is invalid.");
-
+        EnsureValidCatalog(type);
         Type = type;
+    }
+
+    /// <summary>
+    /// Changes the active weapon catalog used by the server.
+    /// </summary>
+    /// <param name="type">
+    /// The weapon catalog to activate.
+    /// </param>
+    public void Change(WeaponCatalogType type)
+    {
+        EnsureValidCatalog(type);
+        Type = type;
+    }
+
+    private static void EnsureValidCatalog(WeaponCatalogType type)
+    {
+        if (!Enum.IsDefined(type))
+            throw new ArgumentOutOfRangeException(
+                paramName: nameof(type),
+                actualValue: type,
+                message: "The weapon catalog type is invalid.");    
     }
 }

--- a/src/Application/Players/Weapons/WeaponCatalog.cs
+++ b/src/Application/Players/Weapons/WeaponCatalog.cs
@@ -33,6 +33,11 @@ public class WeaponCatalog
     public IReadOnlyList<IWeapon> GetAll() => Current.GetAll();
 
     /// <summary>
+    /// Determines whether the specified weapon belongs to this active catalog.
+    /// </summary>
+    public bool Contains(IWeapon weapon) => Current.Contains(weapon);
+
+    /// <summary>
     /// Gets a weapon from the active catalog by its identifier.
     /// </summary>
     public Result<IWeapon> GetById(Weapon id) => Current.GetById(id);

--- a/src/Application/Players/Weapons/WeaponPack.cs
+++ b/src/Application/Players/Weapons/WeaponPack.cs
@@ -29,6 +29,7 @@ public class WeaponPack : IEnumerable<IWeapon>
     }
 
     public void Remove(IWeapon weapon) => _weapons.Remove(weapon);
+    public int RemoveAll(Predicate<IWeapon> predicate) => _weapons.RemoveAll(predicate);
     public bool Exists(IWeapon weapon) => _weapons.Find(w => w == weapon) is not null;
     public void Clear() => _weapons.Clear();
     public IEnumerator<IWeapon> GetEnumerator() => _weapons.GetEnumerator();

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -1,24 +1,11 @@
 ﻿namespace CTF.Application.Players.Weapons;
 
-public class WeaponSystem : ISystem
+public class WeaponSystem(
+    IEntityManager entityManager,
+    IDialogService dialogService,
+    WeaponCatalog weaponCatalog,
+    WeaponCatalogSettings weaponCatalogSettings) : ISystem
 {
-    private readonly IDialogService _dialogService;
-    private readonly ListDialog _weaponsDialog;
-    private readonly WeaponCatalog _weaponCatalog;
-
-    public WeaponSystem(
-        IDialogService dialogService, 
-        WeaponCatalog weaponCatalog)
-    {
-        _dialogService = dialogService;
-        _weaponCatalog = weaponCatalog;
-        _weaponsDialog = new ListDialog("Weapons", "Select", "Close");
-
-        var weapons = weaponCatalog.GetAll();
-        foreach (IWeapon weapon in weapons)
-            _weaponsDialog.Add(weapon.Name);
-    }
-
     [Event]
     public void OnPlayerConnect(Player player)
     {
@@ -73,19 +60,24 @@ public class WeaponSystem : ISystem
     [PlayerCommand("weapons")]
     public async Task ShowWeapons(Player player)
     {
-        var weaponSelection = player.GetComponent<WeaponSelectionComponent>();
-        WeaponPack selectedWeapons = weaponSelection.SelectedWeapons;
-        ListDialogResponse response = await _dialogService.ShowAsync(player, _weaponsDialog);
+        var dialog = new ListDialog("Select Weapons", "Select", "Close");
+        var weapons = weaponCatalog.GetAll();
+        foreach (IWeapon weapon in weapons)
+            dialog.Add(weapon.Name);
+
+        ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
         if (response.IsRightButtonOrDisconnected())
             return;
 
-        Result<IWeapon> weaponResult = _weaponCatalog.GetByIndex(response.ItemIndex);
+        Result<IWeapon> weaponResult = weaponCatalog.GetByName(response.Item.Text);
         if (weaponResult.IsFailed)
         {
             player.SendClientMessage(Color.Red, Messages.WeaponCatalogChanged);
             return;
         }
 
+        var weaponSelection = player.GetComponent<WeaponSelectionComponent>();
+        WeaponPack selectedWeapons = weaponSelection.SelectedWeapons;
         IWeapon weaponSelectedFromDialog = weaponResult.Value;
         if (selectedWeapons.Exists(weaponSelectedFromDialog))
         {
@@ -104,7 +96,7 @@ public class WeaponSystem : ISystem
         await ShowWeapons(player);
     }
 
-    [PlayerCommand("pack")]
+    [PlayerCommand("weaponpack")]
     public async Task ShowWeaponPackage(Player player)
     {
         var weaponSelection = player.GetComponent<WeaponSelectionComponent>();
@@ -114,15 +106,16 @@ public class WeaponSystem : ISystem
             player.SendClientMessage(Color.Red, Messages.EmptyWeaponPackage);
             return;
         }
+
         var dialog = new ListDialog("Your Weapon Pack", "Remove", "Close");
         foreach (IWeapon weapon in selectedWeapons)
             dialog.Add(weapon.Name);
 
-        ListDialogResponse response = await _dialogService.ShowAsync(player, dialog);
+        ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
         if (response.IsRightButtonOrDisconnected())
             return;
 
-        Result<IWeapon> weaponResult = _weaponCatalog.GetByName(response.Item.Text);
+        Result<IWeapon> weaponResult = weaponCatalog.GetByName(response.Item.Text);
         if (weaponResult.IsFailed)
         {
             player.SendClientMessage(Color.Red, Messages.WeaponNoLongerAvailable);
@@ -138,5 +131,46 @@ public class WeaponSystem : ISystem
             player.GiveWeapon(weapon.Id, IWeapon.UnlimitedAmmo);
 
         await ShowWeaponPackage(player);
+    }
+
+    [PlayerCommand("weaponcatalog")]
+    public async Task ShowCatalogs(Player player)
+    {
+        if (player.HasLowerRoleThan(RoleId.Admin))
+            return;
+
+        var dialog = new ListDialog("Weapon Catalogs", "Select", "Close");
+        foreach (WeaponCatalogType type in Enum.GetValues<WeaponCatalogType>())
+            dialog.Add(type.ToString());
+
+        ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
+        if (response.IsRightButtonOrDisconnected())
+            return;
+
+        WeaponCatalogType selectedCatalog = (WeaponCatalogType)response.ItemIndex;
+        if (weaponCatalogSettings.Type == selectedCatalog)
+        {
+            player.SendClientMessage(Color.Red, Messages.WeaponCatalogAlreadyActive);
+            return;
+        }
+
+        weaponCatalogSettings.Change(selectedCatalog);
+
+        foreach (Player currentPlayer in entityManager.GetComponents<Player>())
+        {
+            var weaponSelection = currentPlayer.GetComponent<WeaponSelectionComponent>();
+            WeaponPack selectedWeapons = weaponSelection.SelectedWeapons;
+
+            // Ensure the player's weapon pack only contains weapons
+            // available in the newly selected catalog.
+            selectedWeapons.RemoveAll(weapon => !weaponCatalog.Contains(weapon));
+
+            var message = Smart.Format(Messages.WeaponCatalogChangedTo, new { weaponCatalogSettings.Type });
+            currentPlayer.SendClientMessage(Color.Yellow, message);
+
+            currentPlayer.ResetWeapons();
+            foreach (IWeapon weapon in selectedWeapons)
+                currentPlayer.GiveWeapon(weapon.Id, IWeapon.UnlimitedAmmo);
+        }
     }
 }

--- a/tests/Application.Tests/Players/Weapons/WeaponCatalogSettingsTests.cs
+++ b/tests/Application.Tests/Players/Weapons/WeaponCatalogSettingsTests.cs
@@ -3,7 +3,7 @@
 public class WeaponCatalogSettingsTests
 {
     [Test]
-    public void Constructor_WhenTypeIsInvalid_ShouldThrowArgumentOutOfRangeException()
+    public void Constructor_WhenCatalogTypeIsInvalid_ShouldThrowArgumentOutOfRangeException()
     {
         // Arrange
         WeaponCatalogType type = (WeaponCatalogType)(-1);
@@ -18,7 +18,7 @@ public class WeaponCatalogSettingsTests
     }
 
     [Test]
-    public void Constructor_WhenTypeIsValid_ShouldCreateInstance()
+    public void Constructor_WhenCatalogTypeIsValid_ShouldCreateInstance()
     {
         // Arrange
         WeaponCatalogType type = WeaponCatalogType.Run;
@@ -28,5 +28,34 @@ public class WeaponCatalogSettingsTests
 
         // Assert
         settings.Type.Should().Be(type);
+    }
+
+    [Test]
+    public void Change_WhenCatalogTypeIsInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        var settings = new WeaponCatalogSettings();
+        WeaponCatalogType type = (WeaponCatalogType)(-1);
+
+        // Act
+        Action act = () => settings.Change(type);
+
+        // Assert
+        act.Should()
+           .Throw<ArgumentOutOfRangeException>()
+           .WithParameterName(nameof(type));
+    }
+
+    [Test]
+    public void Change_WhenCatalogTypeIsValid_ShouldUpdateCatalog()
+    {
+        // Arrange
+        var settings = new WeaponCatalogSettings(WeaponCatalogType.Walking);
+
+        // Act
+        settings.Change(WeaponCatalogType.Run);
+
+        // Assert
+        settings.Type.Should().Be(WeaponCatalogType.Run);
     }
 }


### PR DESCRIPTION
This PR adds support for changing the active weapon catalog while the server is running.

When a catalog is changed:

- All players are notified of the new active catalog.
- Weapon packs are synchronized with the selected catalog.
- Weapons that are no longer available are automatically removed.
- Players' weapons are refreshed to reflect the updated selection.
