### PR TITLE
refactor: remove index-based weapon catalog lookups

### DIFF
--- a/src/Application/Players/Weapons/Catalogs/WeaponCatalogBase.cs
+++ b/src/Application/Players/Weapons/Catalogs/WeaponCatalogBase.cs
@@ -77,19 +77,4 @@ public abstract class WeaponCatalogBase
             Result<IWeapon>.Failure(Messages.WeaponNotFound) :
             Result<IWeapon>.Success(weapon);
     }
-
-    /// <summary>
-    /// Gets a weapon by its index in the catalog.
-    /// </summary>
-    /// <remarks>
-    /// This method is primarily used by dialog selections,
-    /// where the selected item is represented by an index.
-    /// </remarks>
-    public Result<IWeapon> GetByIndex(int index)
-    {
-        if (index < 0 || index >= Count)
-            return Result<IWeapon>.Failure(Messages.InvalidWeapon);
-
-        return Result<IWeapon>.Success(_weapons[index]);
-    }
 }

--- a/src/Application/Players/Weapons/WeaponCatalog.cs
+++ b/src/Application/Players/Weapons/WeaponCatalog.cs
@@ -46,9 +46,4 @@ public class WeaponCatalog
     /// Gets a weapon from the active catalog by its display name.
     /// </summary>
     public Result<IWeapon> GetByName(string weaponName) => Current.GetByName(weaponName);
-
-    /// <summary>
-    /// Gets a weapon from the active catalog by its index.
-    /// </summary>
-    public Result<IWeapon> GetByIndex(int index) => Current.GetByIndex(index);
 }

--- a/tests/Application.Tests/Players/Weapons/WeaponCatalogBaseTests.cs
+++ b/tests/Application.Tests/Players/Weapons/WeaponCatalogBaseTests.cs
@@ -83,48 +83,4 @@ public class WeaponCatalogBaseTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Id.Should().Be(expectedWeaponId);
     }
-
-    [TestCase(-1)]
-    [TestCase(-2)]
-    [TestCase(100000)]
-    public void GetByIndex_WhenIndexIsInvalid_ShouldReturnsFailureResult(int index)
-    {
-        // Arrange
-        var catalog = new TestWeaponCatalog();
-        string expectedMessage = Messages.InvalidWeapon;
-
-        // Act
-        Result<IWeapon> result = catalog.GetByIndex(index);
-
-        // Assert
-        result.IsSuccess.Should().BeFalse();
-        result.Message.Should().Be(expectedMessage);
-    }
-
-    [Test]
-    public void GetByIndex_WhenIndexIsEqualToCount_ShouldReturnsFailureResult()
-    {
-        // Arrange
-        var catalog = new TestWeaponCatalog();
-
-        // Act
-        Result<IWeapon> result = catalog.GetByIndex(catalog.Count);
-
-        // Assert
-        result.IsSuccess.Should().BeFalse();
-        result.Message.Should().Be(Messages.InvalidWeapon);
-    }
-
-    [Test]
-    public void GetByIndex_WhenIndexIsValid_ShouldReturnsSuccessResult()
-    {
-        // Arrange
-        var catalog = new TestWeaponCatalog();
-
-        // Act
-        Result<IWeapon> result = catalog.GetByIndex(0);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-    }
 }


### PR DESCRIPTION
Remove `GetByIndex` from `WeaponCatalog` since weapon selections are now resolved using weapon names instead of indices.

Dialog indices are not stable when the active weapon catalog changes at runtime, which may cause outdated dialogs to resolve a different weapon than the one originally selected by the player.

Using weapon names ensures selections remain consistent across catalog changes and makes index-based lookups unnecessary.