### PR TITLE
refactor: extract flag state reset logic

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -7,10 +7,8 @@ public class MapRotationService(
     MapInfoService mapInfoService,
     MapCollection mapCollection,
     MapTextDrawRenderer mapTextDrawRenderer,
-    TeamIconService teamIconService,
-    TeamPickupService teamPickupService,
-    TeamBalancer teamBalancer,
-    FlagAutoReturnTimer flagAutoReturnTimer)
+    FlagStateResetter flagStateResetter,
+    TeamBalancer teamBalancer)
 {
     private LoadTime _loadTime;
     private TimerReference _timerReference;
@@ -76,16 +74,7 @@ public class MapRotationService(
         string message = Smart.Format(Messages.NextMapWillBeLoadedSoon, new { nextMap.Name });
         worldService.SendClientMessage(Color.Orange, message);
         mapInfoService.Load(nextMap);
-        Team.Alpha.Flag.Reset();
-        Team.Beta.Flag.Reset();
-        teamPickupService.DestroyAllPickups();
-        teamPickupService.CreateFlagFromBasePosition(Team.Alpha);
-        teamPickupService.CreateFlagFromBasePosition(Team.Beta);
-        teamIconService.DestroyAll();
-        teamIconService.CreateFromBasePosition(Team.Alpha);
-        teamIconService.CreateFromBasePosition(Team.Beta);
-        flagAutoReturnTimer.Stop(Team.Alpha);
-        flagAutoReturnTimer.Stop(Team.Beta);
+        flagStateResetter.Reset(Team.Alpha, Team.Beta);
         serverService.SendRconCommand($"loadfs {nextMap.Name}");
         serverService.SetMapName(nextMap.Name);
     }

--- a/src/Application/Teams/Flags/FlagStateResetter.cs
+++ b/src/Application/Teams/Flags/FlagStateResetter.cs
@@ -1,0 +1,24 @@
+﻿namespace CTF.Application.Teams.Flags;
+
+public class FlagStateResetter(
+    TeamPickupService teamPickupService,
+    TeamIconService teamIconService,
+    FlagAutoReturnTimer flagAutoReturnTimer)
+{
+    public void Reset(Team alpha, Team beta)
+    {
+        alpha.Flag.Reset();
+        beta.Flag.Reset();
+
+        teamPickupService.DestroyAllPickups();
+        teamPickupService.CreateFlagFromBasePosition(alpha);
+        teamPickupService.CreateFlagFromBasePosition(beta);
+
+        teamIconService.DestroyAll();
+        teamIconService.CreateFromBasePosition(alpha);
+        teamIconService.CreateFromBasePosition(beta);
+
+        flagAutoReturnTimer.Stop(alpha);
+        flagAutoReturnTimer.Stop(beta);
+    }
+}

--- a/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
@@ -12,8 +12,11 @@ public static class FlagServicesExtensions
             .AddSingleton<IFlagEvent, OnFlagScore>()
             .AddSingleton<IFlagEvent, OnFlagTaken>();
 
-        services.AddSingleton<FlagAutoReturnTimer>();
-        services.AddSingleton<OnFlagDropped>();
+        services
+            .AddSingleton<FlagAutoReturnTimer>()
+            .AddSingleton<FlagStateResetter>()
+            .AddSingleton<OnFlagDropped>();
+
         services.AddSingleton<IDictionary<FlagStatus, IFlagEvent>>(serviceProvider =>
         {
             var flagEvents = serviceProvider.GetRequiredService<IEnumerable<IFlagEvent>>();


### PR DESCRIPTION
Extract flag state reset responsibilities from MapRotationService into a dedicated FlagStateResetter service.

This centralizes flag-related reset operations, including flag restoration, pickup recreation, icon recreation, and auto-return timer cleanup, reducing the responsibilities of MapRotationService.