### PR TITLE
refactor: clarify flag return terminology

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1015,15 +1015,6 @@ namespace CTF.Application {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {PlayerName} has reset the {ColorName} flag to its base position.
-        /// </summary>
-        internal static string ResetFlagPosition {
-            get {
-                return ResourceManager.GetString("ResetFlagPosition", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {PlayerName} has reset their stats, such as score, kills and deaths.
         /// </summary>
         internal static string ResetPlayerStats {
@@ -1038,6 +1029,15 @@ namespace CTF.Application {
         internal static string ResetTeamStats {
             get {
                 return ResourceManager.GetString("ResetTeamStats", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {PlayerName} has return the {ColorName} flag to its base position.
+        /// </summary>
+        internal static string ReturnToBasePosition {
+            get {
+                return ResourceManager.GetString("ReturnToBasePosition", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1035,9 +1035,9 @@ namespace CTF.Application {
         /// <summary>
         ///   Looks up a localized string similar to {PlayerName} has return the {ColorName} flag to its base position.
         /// </summary>
-        internal static string ReturnToBasePosition {
+        internal static string ReturnFlagToBasePosition {
             get {
-                return ResourceManager.GetString("ReturnToBasePosition", resourceCulture);
+                return ResourceManager.GetString("ReturnFlagToBasePosition", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -435,7 +435,7 @@
   <data name="ReportToAnotherPlayer" xml:space="preserve">
     <value>{CurrentPlayer} reported to {TargetPlayer} [Reason: {Reason}]</value>
   </data>
-  <data name="ReturnToBasePosition" xml:space="preserve">
+  <data name="ReturnFlagToBasePosition" xml:space="preserve">
     <value>{PlayerName} has return the {ColorName} flag to its base position</value>
   </data>
   <data name="ResetPlayerStats" xml:space="preserve">

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -435,8 +435,8 @@
   <data name="ReportToAnotherPlayer" xml:space="preserve">
     <value>{CurrentPlayer} reported to {TargetPlayer} [Reason: {Reason}]</value>
   </data>
-  <data name="ResetFlagPosition" xml:space="preserve">
-    <value>{PlayerName} has reset the {ColorName} flag to its base position</value>
+  <data name="ReturnToBasePosition" xml:space="preserve">
+    <value>{PlayerName} has return the {ColorName} flag to its base position</value>
   </data>
   <data name="ResetPlayerStats" xml:space="preserve">
     <value>{PlayerName} has reset their stats, such as score, kills and deaths</value>

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.Designer.cs
@@ -114,11 +114,11 @@ namespace CTF.Application.Players.GeneralCommands.Resources {
         /// <summary>
         ///   Looks up a localized string similar to {Color1}/maps: {Color2}Displays a list of available maps in the game.
         ///{Color1}/settimeleft: {Color2}Sets the remaining time for the current game session.
-        ///{Color1}/resetflag: {Color2}Resets the flag of a specific team to its base position.
+        ///{Color1}/returnflag: {Color2}Returns the flag of a specific team to its base position.
         ///{Color1}/startrt: {Color2}Starts the rotation timer for the current map.
         ///{Color1}/stoprt: {Color2}Stops the rotation timer for the current map.
         ///{Color1}/showrm: {Color2}Allows to show flag carriers on the radar map.
-        ///{Color1}/hiderm: {Color2}Allows to hide flag carrie [rest of string was truncated]&quot;;.
+        ///{Color1}/hiderm: {Color2}Allows to hide flag carr [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Moderator {
             get {

--- a/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
+++ b/src/Application/Players/GeneralCommands/Resources/DetailedCommandInfo.resx
@@ -168,7 +168,7 @@ Beware! Enemies will see flag carriers on their radar as well!</value>
   <data name="Moderator" xml:space="preserve">
     <value>{Color1}/maps: {Color2}Displays a list of available maps in the game.
 {Color1}/settimeleft: {Color2}Sets the remaining time for the current game session.
-{Color1}/resetflag: {Color2}Resets the flag of a specific team to its base position.
+{Color1}/returnflag: {Color2}Returns the flag of a specific team to its base position.
 {Color1}/startrt: {Color2}Starts the rotation timer for the current map.
 {Color1}/stoprt: {Color2}Stops the rotation timer for the current map.
 {Color1}/showrm: {Color2}Allows to show flag carriers on the radar map.

--- a/src/Application/Teams/Flags/Systems/ReturnFlagSystem.cs
+++ b/src/Application/Teams/Flags/Systems/ReturnFlagSystem.cs
@@ -27,7 +27,7 @@ public class ReturnFlagSystem(
             return;
         }
 
-        var message = Smart.Format(Messages.ReturnToBasePosition, new
+        var message = Smart.Format(Messages.ReturnFlagToBasePosition, new
         {
             PlayerName = player.Name,
             team.ColorName

--- a/src/Application/Teams/Flags/Systems/ReturnFlagSystem.cs
+++ b/src/Application/Teams/Flags/Systems/ReturnFlagSystem.cs
@@ -1,13 +1,13 @@
 ﻿namespace CTF.Application.Teams.Flags.Systems;
 
-public class ResetFlagSystem(
+public class ReturnFlagSystem(
     IWorldService worldService,
     TeamPickupService teamPickupService,
     TeamSoundsService teamSoundsService,
     FlagAutoReturnTimer flagAutoReturnTimer) : ISystem
 {
-    [PlayerCommand("resetflag")]
-    public void ResetToBasePosition(
+    [PlayerCommand("returnflag")]
+    public void ReturnToBasePosition(
         Player player, 
         [CommandParameter(Name = "red/blue")]string color)
     {
@@ -27,16 +27,12 @@ public class ResetFlagSystem(
             return;
         }
 
-        ResetFlagPosition(player, team);
-    }
-
-    private void ResetFlagPosition(Player player, Team team)
-    {
-        var message = Smart.Format(Messages.ResetFlagPosition, new
+        var message = Smart.Format(Messages.ReturnToBasePosition, new
         {
             PlayerName = player.Name,
             team.ColorName
         });
+
         team.Flag.Carrier?.HideOnRadarMap();
         team.Flag.ReturnToBase();
         teamPickupService.CreateFlagFromBasePosition(team);


### PR DESCRIPTION
Rename flag reset operations to use return terminology.

Returning a flag to its base position is a different concept from resetting the complete flag state. This change makes the domain language more precise and avoids confusion with `FlagStateResetter`.