### PR TITLE
refactor: make MatchResult dependencies explicit

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -62,7 +62,7 @@ public class MapRotationService(
     {
         _isMapLoading = true;
         LoadingMapEvent?.Invoke();
-        var matchResult = MatchResult.Create();
+        var matchResult = MatchResult.Create(Team.Alpha, Team.Beta);
         worldService.SendClientMessage(Color.Yellow, matchResult.Announcement);
         serverService.SendRconCommand($"unloadfs {mapInfoService.CurrentMap.Name}");
 

--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1159,6 +1159,15 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This round was won by the {Name} team.
+        /// </summary>
+        internal static string TeamIsWinner {
+            get {
+                return ResourceManager.GetString("TeamIsWinner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Both teams have the same number of members.
         /// </summary>
         internal static string TeamsAreEqualInMembers {

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -546,4 +546,7 @@
   <data name="WrongSecretKey" xml:space="preserve">
     <value>The secret key you entered is incorrect. Please try again</value>
   </data>
+  <data name="TeamIsWinner" xml:space="preserve">
+    <value>This round was won by the {Name} team</value>
+  </data>
 </root>

--- a/src/Application/Teams/MatchResult.cs
+++ b/src/Application/Teams/MatchResult.cs
@@ -12,13 +12,19 @@ public class MatchResult
         Announcement = announcement;
     }
 
-    public static MatchResult Create()
+    public static MatchResult Create(Team firstTeam, Team secondTeam)
     {
-        if (Team.Alpha.IsWinner())
-            return new MatchResult(Team.Alpha, Messages.AlphaIsWinner);
+        if (firstTeam.IsWinner())
+            return new MatchResult(
+                firstTeam, 
+                Smart.Format(Messages.TeamIsWinner, new { firstTeam.Name })
+            );
 
-        if (Team.Beta.IsWinner())
-            return new MatchResult(Team.Beta, Messages.BetaIsWinner);
+        if (secondTeam.IsWinner())
+            return new MatchResult(
+                secondTeam, 
+                Smart.Format(Messages.TeamIsWinner, new { secondTeam.Name })
+            );
 
         return new MatchResult(Team.None, Messages.TiedTeams);
     }

--- a/tests/Application.Tests/Teams/MatchResultTests.cs
+++ b/tests/Application.Tests/Teams/MatchResultTests.cs
@@ -16,7 +16,7 @@ public class MatchResultTests
         Team.Alpha.StatsPerRound.AddScore();
 
         // Act
-        MatchResult result = MatchResult.Create();
+        MatchResult result = MatchResult.Create(Team.Alpha, Team.Beta);
 
         // Assert
         result.Winner.Should().Be(Team.Alpha);
@@ -31,7 +31,7 @@ public class MatchResultTests
         Team.Beta.StatsPerRound.AddScore();
 
         // Act
-        MatchResult result = MatchResult.Create();
+        MatchResult result = MatchResult.Create(Team.Alpha, Team.Beta);
 
         // Assert
         result.Winner.Should().Be(Team.Beta);
@@ -47,7 +47,7 @@ public class MatchResultTests
         Team.Beta.StatsPerRound.AddScore();
 
         // Act
-        MatchResult result = MatchResult.Create();
+        MatchResult result = MatchResult.Create(Team.Alpha, Team.Beta);
 
         // Assert
         result.Winner.Should().Be(Team.None);


### PR DESCRIPTION
Pass participating teams explicitly when creating a `MatchResult`.

This removes the implicit dependency on `Team.Alpha` and `Team.Beta`, making the API more expressive and allowing match outcome logic to operate on the teams provided by the caller.