### PR TITLE
refactor: make team balancing dependencies explicit

### DIFF
--- a/src/Application/Maps/Services/MapRotationService.cs
+++ b/src/Application/Maps/Services/MapRotationService.cs
@@ -88,7 +88,7 @@ public class MapRotationService(
         CurrentMap currentMap = mapInfoService.CurrentMap;
         string message = Smart.Format(Messages.MapSuccessfullyLoaded, new { currentMap.Name });
         worldService.SendClientMessage(Color.Orange, message);
-        static void HandlePlayerAction(Player player, PlayerInfo playerInfo)
+        static void PreparePlayerForRound(Player player, PlayerInfo playerInfo)
         {
             playerInfo.StatsPerRound.ResetStats();
             player.ToggleControllable(true);
@@ -97,7 +97,7 @@ public class MapRotationService(
             player.SetScore(0);
             player.ToggleSpectating(false);
         }
-        teamBalancer.Balance(action: HandlePlayerAction);
+        teamBalancer.Balance(Team.Alpha, Team.Beta, onPlayerAssigned: PreparePlayerForRound);
         worldService.SetWeather(currentMap.Weather);
         serverService.SetWorldTime(currentMap.WorldTime);
         mapTextDrawRenderer.UpdateMapName(currentMap);

--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -160,6 +160,15 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You have been assigned to {Name} team.
+        /// </summary>
+        internal static string AssignedToTeam {
+            get {
+                return ResourceManager.GetString("AssignedToTeam", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The ban reason must be {Length} characters or less.
         /// </summary>
         internal static string BanReason {

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -549,4 +549,7 @@
   <data name="TeamIsWinner" xml:space="preserve">
     <value>This round was won by the {Name} team</value>
   </data>
+  <data name="AssignedToTeam" xml:space="preserve">
+    <value>You have been assigned to {Name} team</value>
+  </data>
 </root>

--- a/src/Application/Teams/Services/TeamBalancer.cs
+++ b/src/Application/Teams/Services/TeamBalancer.cs
@@ -1,31 +1,38 @@
 ﻿namespace CTF.Application.Teams.Services;
 
 /// <summary>
-/// Balances players between the Alpha and Beta teams based on their score.
+/// Balances players between two teams based on their score.
 /// </summary>
 public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
 {
     /// <summary>
-    /// Reassigns players to teams and executes the specified action
-    /// after each player has been assigned.
+    /// Reassigns players between the specified teams and invokes
+    /// the callback after each player has been assigned.
     /// </summary>
-    /// <param name="action">
-    /// The action to perform for each player after being assigned to a team.
+    /// <param name="firstTeam">
+    /// The first team participating in the balance operation.
+    /// </param>
+    /// <param name="secondTeam">
+    /// The second team participating in the balance operation.
+    /// </param>
+    /// <param name="onPlayerAssigned">
+    /// Invoked after a player has been assigned to a team.
     /// </param>
     /// <remarks>
     /// Players are sorted by score in descending order and then
-    /// alternately assigned to the Alpha and Beta teams.
+    /// alternately assigned to the specified teams.
     /// </remarks>
-    public void Balance(Action<Player, PlayerInfo> action)
+    public void Balance(
+        Team firstTeam,
+        Team secondTeam, 
+        Action<Player, PlayerInfo> onPlayerAssigned)
     {
         Player[] players = MatchPlayers.GetAll()
             .OrderByDescending(player => player.Score)
             .ToArray();
 
-        Team alphaTeam = Team.Alpha;
-        Team betaTeam = Team.Beta;
-        alphaTeam.Reset();
-        betaTeam.Reset();
+        firstTeam.Reset();
+        secondTeam.Reset();
 
         for (int index = 0; index < players.Length; index++)
         {
@@ -44,22 +51,25 @@ public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
 
             if (int.IsEvenInteger(index))
             {
-                alphaTeam.Members.Add(player);
-                playerInfo.SetTeam(alphaTeam.Id);
-                player.SendClientMessage(alphaTeam.ColorHex, Messages.AssignedToAlphaTeam);
+                firstTeam.Members.Add(player);
+                playerInfo.SetTeam(firstTeam.Id);
+                var message = Smart.Format(Messages.AssignedToTeam, new { firstTeam.Name });
+                player.SendClientMessage(firstTeam.ColorHex, message);
             }
             else
             {
-                betaTeam.Members.Add(player);
-                playerInfo.SetTeam(betaTeam.Id);
-                player.SendClientMessage(betaTeam.ColorHex, Messages.AssignedToBetaTeam);
+                secondTeam.Members.Add(player);
+                playerInfo.SetTeam(secondTeam.Id);
+                var message = Smart.Format(Messages.AssignedToTeam, new { secondTeam.Name });
+                player.SendClientMessage(secondTeam.ColorHex, message);
             }
-            action.Invoke(player, playerInfo);
+
+            onPlayerAssigned.Invoke(player, playerInfo);
         }
 
-        teamTextDrawRenderer.UpdateTeamScore(alphaTeam);
-        teamTextDrawRenderer.UpdateTeamScore(betaTeam);
-        teamTextDrawRenderer.UpdateTeamMembers(alphaTeam);
-        teamTextDrawRenderer.UpdateTeamMembers(betaTeam);
+        teamTextDrawRenderer.UpdateTeamScore(firstTeam);
+        teamTextDrawRenderer.UpdateTeamScore(secondTeam);
+        teamTextDrawRenderer.UpdateTeamMembers(firstTeam);
+        teamTextDrawRenderer.UpdateTeamMembers(secondTeam);
     }
 }


### PR DESCRIPTION
Pass the participating teams explicitly to `TeamBalancer` and rename the callback parameter to reflect when it is invoked.

This removes implicit team dependencies, strengthens the domain language, and makes the balancing workflow easier to understand from the caller's perspective.