### PR TITLE
chore: override vulnerable SQLitePCLRaw native dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,8 @@
     <PackageVersion Include="SampSharp.OpenMp.Streamer" Version="1.0.0-prerelease2" />
     <PackageVersion Include="SmartFormat" Version="3.5.2" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="DotEnv.Core" Version="3.1.1" />
     <PackageVersion Include="Dotenv.Extensions.Microsoft.Configuration" Version="3.1.1" />

--- a/src/Persistence/Persistence.SQLite/Persistence.SQLite.csproj
+++ b/src/Persistence/Persistence.SQLite/Persistence.SQLite.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     <PackageReference Include="YeSql.Net" />
   </ItemGroup>
 


### PR DESCRIPTION
Microsoft.Data.Sqlite depends transitively on SQLitePCLRaw.bundle_e_sqlite3 (>= 2.1.11), which resolves to a vulnerable SQLite native library version affected by CVE-2025-6965 (GHSA-2m69-gcr7-jv3q).

Add an explicit reference to SQLitePCLRaw.lib.e_sqlite3 3.50.3 to override the transitive dependency and ensure a patched SQLite native binary is used until Microsoft.Data.Sqlite updates its dependency chain.