### PR TITLE
feat: add display names for weapon catalogs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Dotenv.Extensions.Microsoft.Configuration" Version="3.1.1" />
     <PackageVersion Include="YeSql.Net" Version="2.0.1" />
     <PackageVersion Include="CopySqlFilesToOutputDirectory" Version="1.0.0" />
-    <PackageVersion Include="GameMode.Common" Version="1.0.2" />
+    <PackageVersion Include="GameMode.Common" Version="1.0.4" />
     <PackageVersion Include="seztion-parser" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="FluentAssertions" Version="[7.0.0,8.0.0)" />

--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1258,7 +1258,7 @@ namespace CTF.Application {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The weapon catalog has been changed to &apos;{Type} Weapons&apos;..
+        ///   Looks up a localized string similar to The weapon catalog has been changed to &apos;{Name}&apos;..
         /// </summary>
         internal static string WeaponCatalogChangedTo {
             get {

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -511,7 +511,7 @@
     <value>The weapon catalog has changed. Please open the weapon list again.</value>
   </data>
   <data name="WeaponCatalogChangedTo" xml:space="preserve">
-    <value>The weapon catalog has been changed to '{Type} Weapons'.</value>
+    <value>The weapon catalog has been changed to '{Name}'.</value>
   </data>
   <data name="WeaponListUsage" xml:space="preserve">
     <value>Press Y to show the available weapons</value>

--- a/src/Application/Players/Weapons/Catalogs/WeaponCatalogType.cs
+++ b/src/Application/Players/Weapons/Catalogs/WeaponCatalogType.cs
@@ -5,7 +5,12 @@
 /// </summary>
 public enum WeaponCatalogType
 {
+    [DisplayName("Walking Weapons")]
     Walking,
+
+    [DisplayName("Run Weapons")]
     Run,
-    Mixed
+
+    [DisplayName("Mixed Weapons")]
+    Mixed,
 }

--- a/src/Application/Players/Weapons/WeaponSystem.cs
+++ b/src/Application/Players/Weapons/WeaponSystem.cs
@@ -13,7 +13,7 @@ public class WeaponSystem(
     }
 
     [Event]
-    public async Task OnPlayerRequestSpawn(Player player) 
+    public async Task OnPlayerRequestSpawn(Player player)
     {
         await ShowWeapons(player);
         player.SendClientMessage(Color.Orange, Messages.WeaponListUsage);
@@ -31,7 +31,7 @@ public class WeaponSystem(
         {
             await ShowWeapons(player);
         }
-        else if (KeyUtils.HasPressed(newKeys,oldKeys, Keys.CtrlBack))
+        else if (KeyUtils.HasPressed(newKeys, oldKeys, Keys.CtrlBack))
         {
             await ShowWeaponPackage(player);
         }
@@ -138,7 +138,7 @@ public class WeaponSystem(
 
         var dialog = new ListDialog("Weapon Catalogs", "Select", "Close");
         foreach (WeaponCatalogType type in Enum.GetValues<WeaponCatalogType>())
-            dialog.Add(type.ToString());
+            dialog.Add(type.GetDisplayName());
 
         ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
         if (response.IsRightButtonOrDisconnected())
@@ -152,7 +152,9 @@ public class WeaponSystem(
         }
 
         weaponCatalogSettings.Change(selectedCatalog);
-        
+        var catalogName = selectedCatalog.GetDisplayName();
+        var message = Smart.Format(Messages.WeaponCatalogChangedTo, new { Name = catalogName });
+
         foreach (Player currentPlayer in entityManager.GetComponents<Player>())
         {
             var weaponSelection = currentPlayer.GetComponent<WeaponSelectionComponent>();
@@ -170,7 +172,6 @@ public class WeaponSystem(
                 return shouldRemove;
             });
 
-            var message = Smart.Format(Messages.WeaponCatalogChangedTo, new { weaponCatalogSettings.Type });
             currentPlayer.SendClientMessage(Color.Yellow, message);
         }
     }

--- a/tests/Application.Tests/Players/Weapons/WeaponCatalogTypeTests.cs
+++ b/tests/Application.Tests/Players/Weapons/WeaponCatalogTypeTests.cs
@@ -1,0 +1,14 @@
+﻿namespace CTF.Application.Tests.Players.Weapons;
+
+public class WeaponCatalogTypeTests
+{
+    [Test]
+    public void AllValues_ShouldHaveDisplayName()
+    {
+        foreach (WeaponCatalogType type in Enum.GetValues<WeaponCatalogType>())
+        {
+            Action action = () => type.GetDisplayName();
+            action.Should().NotThrow();
+        }
+    }
+}


### PR DESCRIPTION
* Add display names to weapon catalog types.
* Use enum metadata instead of `ToString()` in dialogs.
* Reuse catalog display names in player notifications.
* Centralize user-facing catalog names in `WeaponCatalogType`.
* Update `GameMode.Common` to use the `DisplayName` attribute.