### PR TITLE
refactor: clarify player extension method contracts

### DIFF
--- a/src/Application/Players/Accounts/Services/PlayerStatsRenderer.cs
+++ b/src/Application/Players/Accounts/Services/PlayerStatsRenderer.cs
@@ -33,7 +33,7 @@ public class PlayerStatsRenderer(IWorldService worldService)
     {
         ArgumentNullException.ThrowIfNull(player);
         PlayerStatsTextDraw playerStatsTextDraw = GetTextDrawOrThrow(player);
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerStatsTextDraw.Value.Text = playerInfo.GetStatsAsText();
         playerStatsTextDraw.Value.Show();
     }

--- a/src/Application/Players/Accounts/Services/SignupDialogViewer.cs
+++ b/src/Application/Players/Accounts/Services/SignupDialogViewer.cs
@@ -30,7 +30,7 @@ public class SignupDialogViewer(
 
     private async Task CreatePlayerAccount(Player connectedPlayer, string enteredPassword)
     {
-        PlayerInfo playerInfo = connectedPlayer.GetInfo();
+        PlayerInfo playerInfo = connectedPlayer.GetRequiredInfo();
         Result passwordResult = playerInfo.SetPassword(enteredPassword);
         if (passwordResult.IsFailed)
         {

--- a/src/Application/Players/Accounts/Systems/ChangeNameSystem.cs
+++ b/src/Application/Players/Accounts/Systems/ChangeNameSystem.cs
@@ -13,7 +13,7 @@ public class ChangeNameSystem(
             return;
         }
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         string oldName = playerInfo.Name;
         Result result = playerInfo.SetName(newName);
         if (result.IsFailed)

--- a/src/Application/Players/Accounts/Systems/ChangePasswordSystem.cs
+++ b/src/Application/Players/Accounts/Systems/ChangePasswordSystem.cs
@@ -26,7 +26,7 @@ public class ChangePasswordSystem(
 
     private async Task ChangePassword(Player player, string enteredPassword)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         Result result = playerInfo.SetPassword(enteredPassword);
         if (result.IsFailed)
         {

--- a/src/Application/Players/Accounts/Systems/ChangeRoleSystem.cs
+++ b/src/Application/Players/Accounts/Systems/ChangeRoleSystem.cs
@@ -26,7 +26,7 @@ public class ChangeRoleSystem(
             return;
         }
 
-        PlayerInfo targetPlayerInfo = targetPlayer.GetInfo();
+        PlayerInfo targetPlayerInfo = targetPlayer.GetRequiredInfo();
         RoleId newRoleId = (RoleId)roleId;
         RoleId oldRoleId = targetPlayerInfo.RoleId;
         Result result = targetPlayerInfo.SetRole(newRoleId);
@@ -106,7 +106,7 @@ public class ChangeRoleSystem(
         }
 
         var gameText = Smart.Format(Messages.PromotedToRole, new { RoleName = RoleId.Admin });
-        PlayerInfo playerInfo = currentPlayer.GetInfo();
+        PlayerInfo playerInfo = currentPlayer.GetRequiredInfo();
         playerInfo.SetRole(RoleId.Admin);
         playerRepository.UpdateRole(playerInfo);
         currentPlayer.GameText(gameText, TimeSpan.FromSeconds(4), GameTextStyle.Style3);

--- a/src/Application/Players/Accounts/Systems/ChangeSkinSystem.cs
+++ b/src/Application/Players/Accounts/Systems/ChangeSkinSystem.cs
@@ -5,7 +5,7 @@ public class ChangeSkinSystem(IPlayerRepository playerRepository) : ISystem
     [PlayerCommand("skin")]
     public void SetSkin(Player player, [CommandParameter(Name = "skinId")]int newSkinId)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         int oldSkinId = playerInfo.SkinId;
         Result result = playerInfo.SetSkin(newSkinId);
         if (result.IsFailed)

--- a/src/Application/Players/Accounts/Systems/PlayerCoinsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerCoinsSystem.cs
@@ -16,7 +16,7 @@ public class PlayerCoinsSystem(
         if (currentPlayer.HasLowerRoleThan(RoleId.Admin))
             return;
 
-        PlayerInfo targetPlayerInfo = targetPlayer.GetInfo();
+        PlayerInfo targetPlayerInfo = targetPlayer.GetRequiredInfo();
         Result result = targetPlayerInfo.StatsPerRound.AddCoins(coins);
         if (result.IsFailed)
         {
@@ -52,7 +52,7 @@ public class PlayerCoinsSystem(
         IEnumerable<Player> players = entityManager.GetComponents<Player>();
         foreach (Player targetPlayer in players)
         {
-            PlayerInfo targetPlayerInfo = targetPlayer.GetInfo();
+            PlayerInfo targetPlayerInfo = targetPlayer.GetRequiredInfo();
             Result result = targetPlayerInfo.StatsPerRound.AddCoins(coins);
             if (result.IsFailed)
             {
@@ -90,7 +90,7 @@ public class PlayerCoinsSystem(
         static int ConvertMinutesToSeconds(int value) => value * 60;
         int seconds = ConvertMinutesToSeconds(commandCooldowns.Coins);
         waitTimeComponent.Value = unixTimeSeconds.Value + seconds;
-        PlayerInfo currentPlayerInfo = currentPlayer.GetInfo();
+        PlayerInfo currentPlayerInfo = currentPlayer.GetRequiredInfo();
         currentPlayerInfo.StatsPerRound.AddCoins(100);
         playerStatsRenderer.UpdateTextDraw(currentPlayer);
         currentPlayer.SendClientMessage(Color.Yellow, Messages.GiveMeCoins);

--- a/src/Application/Players/Accounts/Systems/PlayerKillsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerKillsSystem.cs
@@ -19,7 +19,7 @@ public class PlayerKillsSystem(
             return;
         }
 
-        PlayerInfo targetPlayerInfo = targetPlayer.GetInfo();
+        PlayerInfo targetPlayerInfo = targetPlayer.GetRequiredInfo();
         Result result = targetPlayerInfo.SetTotalKills(kills);
         if (result.IsFailed)
         {

--- a/src/Application/Players/Accounts/Systems/PlayerStatsSystem.cs
+++ b/src/Application/Players/Accounts/Systems/PlayerStatsSystem.cs
@@ -26,7 +26,7 @@ public class PlayerStatsSystem(
         if (player.IsUnauthenticated())
             return;
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.SetLastConnection();
         playerRepository.UpdateLastConnection(playerInfo);
     }
@@ -34,7 +34,7 @@ public class PlayerStatsSystem(
     [Event]
     public void OnPlayerDeath(Player deadPlayer, Player killer, Weapon reason)
     {
-        PlayerInfo deadPlayerInfo = deadPlayer.GetInfo();
+        PlayerInfo deadPlayerInfo = deadPlayer.GetRequiredInfo();
         deadPlayerInfo.StatsPerRound.AddDeaths();
         deadPlayerInfo.StatsPerRound.ResetKillingSpree();
         deadPlayerInfo.AddTotalDeaths();
@@ -43,7 +43,7 @@ public class PlayerStatsSystem(
         if (killer.IsInvalidPlayer())
             return;
 
-        PlayerInfo killerInfo = killer.GetInfo();
+        PlayerInfo killerInfo = killer.GetRequiredInfo();
         killerInfo.StatsPerRound.AddKills();
         killerInfo.AddTotalKills();
         killer.AddScore();
@@ -65,7 +65,7 @@ public class PlayerStatsSystem(
     [PlayerCommand("re")]
     public void ResetPlayerStats(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.ResetKills();
         playerInfo.StatsPerRound.ResetDeaths();
         player.SetScore(0);
@@ -95,7 +95,7 @@ public class PlayerStatsSystem(
 
     private static string GetPlayerContent(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         string createdAt = player.IsUnauthenticated() ? 
             "None" : 
             playerInfo.CreatedAt.ToIsoDateString();

--- a/src/Application/Players/Chats/ChatSystem.cs
+++ b/src/Application/Players/Chats/ChatSystem.cs
@@ -27,7 +27,7 @@ public class ChatSystem(IDictionary<char, IChatMessage> chats) : ISystem
         char identifier = text[0];
         if (chats.TryGetValue(identifier, out IChatMessage chatMessage)) 
         {
-            PlayerInfo sender = player.GetInfo();
+            PlayerInfo sender = player.GetRequiredInfo();
             ReplaceFirstCharacter(text, newCharacter: ' ');
             bool sendMessageByDefault = !chatMessage.SendToAllPlayers(sender, text);
             ReplaceFirstCharacter(text, newCharacter: identifier);

--- a/src/Application/Players/Chats/PrivateMessageSystem.cs
+++ b/src/Application/Players/Chats/PrivateMessageSystem.cs
@@ -32,7 +32,7 @@ public class PrivateMessageSystem(IEntityManager entityManager) : ISystem
         var players = entityManager.GetComponents<Player>();
         foreach (Player player in players)
         {
-            PlayerInfo playerInfo = player.GetInfo();
+            PlayerInfo playerInfo = player.GetRequiredInfo();
             if (playerInfo.HasLowerRoleThan(RoleId.Moderator))
                 continue;
 

--- a/src/Application/Players/Chats/Types/PrivateAdminChat.cs
+++ b/src/Application/Players/Chats/Types/PrivateAdminChat.cs
@@ -14,7 +14,7 @@ public class PrivateAdminChat(IEntityManager entityManager) : IChatMessage
             if (player.IsInClassSelection())
                 continue;
 
-            PlayerInfo playerInfo = player.GetInfo();
+            PlayerInfo playerInfo = player.GetRequiredInfo();
             if (playerInfo.HasLowerRoleThan(RoleId.Admin))
                 continue;
 

--- a/src/Application/Players/Chats/Types/PrivateModeratorChat.cs
+++ b/src/Application/Players/Chats/Types/PrivateModeratorChat.cs
@@ -14,7 +14,7 @@ public class PrivateModeratorChat(IEntityManager entityManager) : IChatMessage
             if (player.IsInClassSelection())
                 continue;
 
-            PlayerInfo playerInfo = player.GetInfo();
+            PlayerInfo playerInfo = player.GetRequiredInfo();
             if (playerInfo.HasLowerRoleThan(RoleId.Moderator))
                 continue;
 

--- a/src/Application/Players/Chats/Types/PrivateVipChat.cs
+++ b/src/Application/Players/Chats/Types/PrivateVipChat.cs
@@ -14,7 +14,7 @@ public class PrivateVipChat(IEntityManager entityManager) : IChatMessage
             if (player.IsInClassSelection())
                 continue;
 
-            PlayerInfo playerInfo = player.GetInfo();
+            PlayerInfo playerInfo = player.GetRequiredInfo();
             if (playerInfo.HasLowerRoleThan(RoleId.VIP))
                 continue;
 

--- a/src/Application/Players/Combos/ComboSystem.cs
+++ b/src/Application/Players/Combos/ComboSystem.cs
@@ -51,7 +51,7 @@ public class ComboSystem : ISystem
 
         string selectedItemName = response.Item.Columns[0];
         ICombo selectedCombo = _combos.First(combo => combo.Name == selectedItemName);
-        PlayerStatsPerRound playerStats = player.GetInfo().StatsPerRound;
+        PlayerStatsPerRound playerStats = player.GetRequiredInfo().StatsPerRound;
         if (playerStats.HasInsufficientCoins(selectedCombo.RequiredCoins))
         {
             player.SendClientMessage(Color.Red, Messages.InsufficientCoins);

--- a/src/Application/Players/Combos/Definitions/FlamethrowerVitality.cs
+++ b/src/Application/Players/Combos/Definitions/FlamethrowerVitality.cs
@@ -7,7 +7,7 @@ public class FlamethrowerVitality : ICombo
 
     public Result Give(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         player.Health = 100;
         player.Armour = 100;
         // 1000 (shows in game as 50-50).

--- a/src/Application/Players/Combos/Definitions/GrenadesVitality.cs
+++ b/src/Application/Players/Combos/Definitions/GrenadesVitality.cs
@@ -7,7 +7,7 @@ public class GrenadesVitality : ICombo
 
     public Result Give(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.Grenade, ammo: 6);

--- a/src/Application/Players/Combos/Definitions/MolotovVitality.cs
+++ b/src/Application/Players/Combos/Definitions/MolotovVitality.cs
@@ -7,7 +7,7 @@ public class MolotovVitality : ICombo
 
     public Result Give(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.Moltov, ammo: 6);

--- a/src/Application/Players/Combos/Definitions/RocketLauncherVitality.cs
+++ b/src/Application/Players/Combos/Definitions/RocketLauncherVitality.cs
@@ -13,7 +13,7 @@ public class RocketLauncherVitality(ComboSettings comboSettings) : ICombo
             return Result.Failure();
         }
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         player.Health = 100;
         player.GiveWeapon(Weapon.RocketLauncher, ammo: 2);
         playerInfo.StatsPerRound.ResetCoins();

--- a/src/Application/Players/Combos/Definitions/SatchelChargesVitality.cs
+++ b/src/Application/Players/Combos/Definitions/SatchelChargesVitality.cs
@@ -7,7 +7,7 @@ public class SatchelChargesVitality : ICombo
 
     public Result Give(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.SatchelCharge, ammo: 6);

--- a/src/Application/Players/Combos/Definitions/TearGasVitality.cs
+++ b/src/Application/Players/Combos/Definitions/TearGasVitality.cs
@@ -7,7 +7,7 @@ public class TearGasVitality : ICombo
 
     public Result Give(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         player.Health = 100;
         player.Armour = 100;
         player.GiveWeapon(Weapon.Teargas, ammo: 30);

--- a/src/Application/Players/Extensions/PlayerColorExtensions.cs
+++ b/src/Application/Players/Extensions/PlayerColorExtensions.cs
@@ -11,7 +11,7 @@ public static class PlayerColorExtensions
     /// </remarks>
     public static void ShowOnRadarMap(this Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         Color teamColor = playerInfo.Team.ColorHex;
         player.Color = new Color(teamColor.R, teamColor.G, teamColor.B, 255f);
     }
@@ -25,7 +25,7 @@ public static class PlayerColorExtensions
     /// </remarks>
     public static void HideOnRadarMap(this Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         Color teamColor = playerInfo.Team.ColorHex;
         player.Color = new Color(teamColor.R, teamColor.G, teamColor.B, 00f);
     }

--- a/src/Application/Players/Extensions/PlayerExtensions.cs
+++ b/src/Application/Players/Extensions/PlayerExtensions.cs
@@ -3,40 +3,45 @@
 public static class PlayerExtensions
 {
     /// <summary>
-    /// Gets the information from a player.
+    /// Gets the information associated with the specified player.
     /// </summary>
-    /// <param name="player">The current player.</param>
+    /// <param name="player">
+    /// The player whose information should be retrieved.
+    /// </param>
     /// <returns>
-    /// An instance of type <see cref="PlayerInfo"/>.
+    /// The player's information.
     /// </returns>
     /// <exception cref="InvalidOperationException">
-    /// when the <see cref="AccountComponent"/> component is not attached to the player.
+    /// Thrown when the player does not have an attached
+    /// <see cref="AccountComponent"/>.
     /// </exception>
-    public static PlayerInfo GetInfo(this Player player)
+    public static PlayerInfo GetRequiredInfo(this Player player)
     {
         AccountComponent accountComponent = player.GetComponent<AccountComponent>();
-        return accountComponent is null ?
-            throw new InvalidOperationException($"The '{nameof(AccountComponent)}' component is not attached to the player") :
-            accountComponent.PlayerInfo;
+        return accountComponent?.PlayerInfo
+            ?? throw new InvalidOperationException(
+                $"The player is missing the required {nameof(AccountComponent)}.");
     }
 
     /// <summary>
-    /// Checks if the player is unauthenticated.
+    /// Determines whether the specified player is unauthenticated.
     /// </summary>
     /// <param name="player">
-    /// The player to check for authentication status.
+    /// The player whose authentication status should be checked.
     /// </param>
     /// <returns>
-    /// <c>true</c> if the player is unauthenticated; otherwise, <c>false</c>.
+    /// <see langword="true"/> if the player is unauthenticated;
+    /// otherwise, <see langword="false"/>.
     /// </returns>
     /// <exception cref="InvalidOperationException">
-    /// when the <see cref="AccountComponent"/> component is not attached to the player.
+    /// Thrown when the player does not have an attached
+    /// <see cref="AccountComponent"/>.
     /// </exception>
     public static bool IsUnauthenticated(this Player player)
     {
         AccountComponent accountComponent = player.GetComponent<AccountComponent>();
-        return accountComponent is null ?
-            throw new InvalidOperationException($"The '{nameof(AccountComponent)}' component is not attached to the player") :
-            accountComponent.IsUnauthenticated;
+        return accountComponent?.IsUnauthenticated
+            ?? throw new InvalidOperationException(
+                $"The player is missing the required {nameof(AccountComponent)}.");
     }
 }

--- a/src/Application/Players/Extensions/PlayerRoleExtensions.cs
+++ b/src/Application/Players/Extensions/PlayerRoleExtensions.cs
@@ -4,7 +4,7 @@ public static class PlayerRoleExtensions
 {
     public static bool HasLowerRoleThan(this Player player, RoleId id)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.HasLowerRoleThan(id))
         {
             player.SendClientMessage(Color.Red, Messages.NoPermissions);

--- a/src/Application/Players/Extensions/PlayerTeamExtensions.cs
+++ b/src/Application/Players/Extensions/PlayerTeamExtensions.cs
@@ -16,7 +16,7 @@ public static class PlayerTeamExtensions
         if (player.Team == (int)TeamId.NoTeam)
             return Team.None;
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         Team currentTeam = playerInfo.Team;
         currentTeam.Members.Remove(player);
         playerInfo.SetTeam(TeamId.NoTeam);

--- a/src/Application/Players/GeneralCommands/Public/PublicCommands.cs
+++ b/src/Application/Players/GeneralCommands/Public/PublicCommands.cs
@@ -31,7 +31,7 @@ public class PublicCommands(
     [PlayerCommand("kill")]
     public void Kill(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.Team == Team.None)
         {
             player.SendClientMessage(Color.Red, Messages.NoTeam);
@@ -45,7 +45,7 @@ public class PublicCommands(
     {
         IEnumerable<PlayerInfo> admins = entityManager
             .GetComponents<Player>()
-            .Select(player => player.GetInfo())
+            .Select(player => player.GetRequiredInfo())
             .Where(playerInfo => playerInfo.RoleId >= RoleId.Moderator)
             .OrderByDescending(playerInfo => playerInfo.RoleId);
 
@@ -68,7 +68,7 @@ public class PublicCommands(
     {
         IEnumerable<PlayerInfo> vips = entityManager
             .GetComponents<Player>()
-            .Select(player => player.GetInfo())
+            .Select(player => player.GetRequiredInfo())
             .Where(playerInfo => playerInfo.RoleId >= RoleId.VIP);
 
         int count = vips.Count();
@@ -99,7 +99,7 @@ public class PublicCommands(
 
         IEnumerable<Player> admins = entityManager
             .GetComponents<Player>()
-            .Where(player => player.GetInfo().RoleId >= RoleId.Moderator);
+            .Where(player => player.GetRequiredInfo().RoleId >= RoleId.Moderator);
 
         if (!admins.Any())
         {
@@ -139,7 +139,7 @@ public class PublicCommands(
             return;
         }
 
-        if (currentPlayer.GetInfo().IsCarryingEnemyFlag())
+        if (currentPlayer.GetRequiredInfo().IsCarryingEnemyFlag())
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.HasCapturedFlag);
             return;

--- a/src/Application/Players/Headshots/HeadshotSystem.cs
+++ b/src/Application/Players/Headshots/HeadshotSystem.cs
@@ -36,8 +36,8 @@ public class HeadshotSystem(
 
         if (issuer.Team != receiver.Team && weapon == Weapon.Sniper && bodyPart == BodyPart.Head)
         {
-            PlayerInfo issuerInfo = issuer.GetInfo();
-            PlayerInfo receiverInfo = receiver.GetInfo();
+            PlayerInfo issuerInfo = issuer.GetRequiredInfo();
+            PlayerInfo receiverInfo = receiver.GetRequiredInfo();
             issuerInfo.AddHeadShots();
             issuerInfo.StatsPerRound.AddCoins(5);
             playerRepository.UpdateHeadShots(issuerInfo);

--- a/src/Application/Players/PlayerSpawnSystem.cs
+++ b/src/Application/Players/PlayerSpawnSystem.cs
@@ -8,7 +8,7 @@ public class PlayerSpawnSystem(
     public void OnPlayerSpawn(Player player)
     {
         CurrentMap currentMap = mapInfoService.CurrentMap;
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         SpawnLocation spawnLocation = currentMap.GetRandomSpawnLocation(playerInfo.Team.Id);
         player.Position = spawnLocation.Position;
         player.Angle = spawnLocation.Angle;

--- a/src/Application/Teams/ClassSelection/ClassSelectionSystem.cs
+++ b/src/Application/Teams/ClassSelection/ClassSelectionSystem.cs
@@ -59,7 +59,7 @@ public class ClassSelectionSystem(
         Team selectedTeam = player.Team == (int)TeamId.Alpha ? Team.Alpha : Team.Beta;
         player.DisableClassSelection();
         player.HideGameText(style: 3);
-        player.GetInfo().SetTeam(selectedTeam.Id);
+        player.GetRequiredInfo().SetTeam(selectedTeam.Id);
         player.StopAudioStream();
         selectedTeam.Members.Add(player);
         classSelectionTextDrawRenderer.Hide(player);
@@ -79,7 +79,7 @@ public class ClassSelectionSystem(
         if (player.IsUnauthenticated())
             return;
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.Team == Team.None)
             return;
 
@@ -90,7 +90,7 @@ public class ClassSelectionSystem(
     [PlayerCommand("class")]
     public void RedirectToClassSelection(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.IsCarryingEnemyFlag())
         {
             player.SendClientMessage(Color.Red, Messages.HasCapturedFlag);

--- a/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
@@ -27,7 +27,7 @@ public class OnFlagCaptured(
         worldService.SendClientMessage(team.ColorHex, message);
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag captured!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.AddCoins(5);
         playerInfo.AddCapturedFlags();
         player.AddScore(2);

--- a/src/Application/Teams/Flags/Events/OnFlagDropped.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagDropped.cs
@@ -27,7 +27,7 @@ public class OnFlagDropped(
         worldService.SendClientMessage(team.ColorHex, message);
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag dropped!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.AddDroppedFlags();
         player.HideOnRadarMap();
         playerRepository.UpdateDroppedFlags(playerInfo);

--- a/src/Application/Teams/Flags/Events/OnFlagReturned.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagReturned.cs
@@ -28,7 +28,7 @@ public class OnFlagReturned(
         worldService.SendClientMessage(team.ColorHex, message);
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.AddCoins(5);
         playerInfo.AddReturnedFlags();
         player.AddScore(2);

--- a/src/Application/Teams/Flags/Events/OnFlagScore.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagScore.cs
@@ -29,7 +29,7 @@ public class OnFlagScore(
         worldService.SendClientMessage(team.ColorHex, message);
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} team scores!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.AddCoins(8);
         playerInfo.AddBroughtFlags();
         player.AddScore(4);
@@ -43,7 +43,7 @@ public class OnFlagScore(
         TeamMembers teamMembers = team.Members;
         foreach (Player player in teamMembers)
         {
-            PlayerInfo playerInfo = player.GetInfo();
+            PlayerInfo playerInfo = player.GetRequiredInfo();
             playerInfo.StatsPerRound.AddCoins(5);
             player.AddHealth(10);
             player.AddScore(1);

--- a/src/Application/Teams/Flags/Systems/FlagCarrierPauseHandler.cs
+++ b/src/Application/Teams/Flags/Systems/FlagCarrierPauseHandler.cs
@@ -26,7 +26,7 @@ public class FlagCarrierPauseHandler(
     [Event]
     public void OnPlayerPauseStateChange(Player player, bool pauseState)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (pauseState && playerInfo.IsCarryingEnemyFlag())
         {
             var interval = TimeSpan.FromSeconds(flagCarrierSettings.PauseTime);

--- a/src/Application/Teams/Flags/Systems/FlagSystem.cs
+++ b/src/Application/Teams/Flags/Systems/FlagSystem.cs
@@ -8,7 +8,7 @@ public class FlagSystem(
     [Event]
     public void OnPlayerDisconnect(Player player, DisconnectReason reason)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.IsCarryingEnemyFlag())
         {
             Team currentTeam = playerInfo.Team;
@@ -19,14 +19,14 @@ public class FlagSystem(
     [Event]
     public void OnPlayerDeath(Player deadPlayer, Player killer, Weapon reason)
     {
-        PlayerInfo deadPlayerInfo = deadPlayer.GetInfo();
+        PlayerInfo deadPlayerInfo = deadPlayer.GetRequiredInfo();
         if (deadPlayerInfo.IsCarryingEnemyFlag())
         {
             Team currentTeam = deadPlayerInfo.Team;
             onFlagDropped.Handle(currentTeam.RivalTeam, deadPlayer);
             if (killer.IsValidPlayer())
             {
-                PlayerInfo killerInfo = killer.GetInfo();
+                PlayerInfo killerInfo = killer.GetRequiredInfo();
                 killerInfo.StatsPerRound.AddCoins(4);
                 killer.AddHealth(10);
                 killer.AddScore(2);

--- a/src/Application/Teams/Services/TeamBalancer.cs
+++ b/src/Application/Teams/Services/TeamBalancer.cs
@@ -37,7 +37,7 @@ public class TeamBalancer(TeamTextDrawRenderer teamTextDrawRenderer)
         for (int index = 0; index < players.Length; index++)
         {
             Player player = players[index];
-            PlayerInfo playerInfo = player.GetInfo();
+            PlayerInfo playerInfo = player.GetRequiredInfo();
             if (player.IsPaused())
             {
                 playerInfo.StatsPerRound.ResetStats();

--- a/src/Application/Teams/Systems/ChangeTeamSystem.cs
+++ b/src/Application/Teams/Systems/ChangeTeamSystem.cs
@@ -9,7 +9,7 @@ public class ChangeTeamSystem(
     [PlayerCommand("team")]
     public async Task ShowTeams(Player player)
     {
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.Team == Team.None)
         {
             player.SendClientMessage(Color.Red, Messages.NoTeam);
@@ -53,7 +53,7 @@ public class ChangeTeamSystem(
     {
         Team alphaTeam = Team.Alpha;
         Team betaTeam = Team.Beta;
-        PlayerInfo playerInfo = player.GetInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         if (playerInfo.Team == selectedTeam)
         {
             player.SendClientMessage(Color.Red, Messages.PlayerIsAlreadyInTeam);

--- a/src/Application/Teams/Systems/ScoreBoardSystem.cs
+++ b/src/Application/Teams/Systems/ScoreBoardSystem.cs
@@ -37,7 +37,7 @@ public class ScoreBoardSystem(IDialogService dialogService) : ISystem
             .OrderByDescending(player => player.Score);
         foreach (Player teamMember in alphaTeamMembers) 
         {
-            PlayerInfo teamMemberInfo = teamMember.GetInfo();
+            PlayerInfo teamMemberInfo = teamMember.GetRequiredInfo();
             string[] columns = [
                 $"{alphaTeam.ColorHex}{teamMember.Name}",
                 $"{alphaTeam.ColorHex}{teamMember.Score}",
@@ -52,7 +52,7 @@ public class ScoreBoardSystem(IDialogService dialogService) : ISystem
             .OrderByDescending(player => player.Score);
         foreach (Player teamMember in betaTeamMembers)
         {
-            PlayerInfo teamMemberInfo = teamMember.GetInfo();
+            PlayerInfo teamMemberInfo = teamMember.GetRequiredInfo();
             string[] columns = [
                 $"{betaTeam.ColorHex}{teamMember.Name}",
                 $"{betaTeam.ColorHex}{teamMember.Score}",

--- a/src/Application/Teams/Systems/TeamStatsSystem.cs
+++ b/src/Application/Teams/Systems/TeamStatsSystem.cs
@@ -14,13 +14,13 @@ public class TeamStatsSystem(
     [Event]
     public void OnPlayerDeath(Player deadPlayer, Player killer, Weapon reason)
     {
-        PlayerInfo deadPlayerInfo = deadPlayer.GetInfo();
+        PlayerInfo deadPlayerInfo = deadPlayer.GetRequiredInfo();
         deadPlayerInfo.Team.StatsPerRound.AddDeaths();
 
         if (killer.IsInvalidPlayer())
             return;
 
-        PlayerInfo killerInfo = killer.GetInfo();
+        PlayerInfo killerInfo = killer.GetRequiredInfo();
         killerInfo.Team.StatsPerRound.AddKills();
     }
 

--- a/tests/Application.Tests/Players/Extensions/PlayerExtensionsTests.cs
+++ b/tests/Application.Tests/Players/Extensions/PlayerExtensionsTests.cs
@@ -3,26 +3,26 @@
 public class PlayerExtensionsTests
 {
     [Test]
-    public void GetInfo_WhenNoAccountComponent_ShouldThrowInvalidOperationException()
+    public void GetRequiredInfo_WhenNoAccountComponent_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var fakePlayer = new FakePlayer2();
 
         // Act
-        Action act = () => fakePlayer.GetInfo();
+        Action act = () => fakePlayer.GetRequiredInfo();
 
         // Assert
         act.Should().Throw<InvalidOperationException>();
     }
 
     [Test]
-    public void GetInfo_WhenAccountComponentIsAssigned_ShouldNotThrowInvalidOperationException()
+    public void GetRequiredInfo_WhenAccountComponentIsAssigned_ShouldNotThrowInvalidOperationException()
     {
         // Arrange
         var fakePlayer = new FakePlayer3();
 
         // Act
-        Action act = () => fakePlayer.GetInfo();
+        Action act = () => fakePlayer.GetRequiredInfo();
 
         // Assert
         act.Should().NotThrow<InvalidOperationException>();


### PR DESCRIPTION
* Rename `PlayerExtensions.GetInfo` to `PlayerExtensions.GetRequiredInfo` to make its required semantics explicit.
* Follow the .NET API pattern used by methods such as `IServiceProvider.GetRequiredService` and `Configuration.GetRequiredSection`, where the method name communicates that the requested object is required and an exception is thrown if it is missing.
* Improve XML documentation and exception messages for player extension methods.