### PR TITLE
refactor: simplify account authentication flow

### DIFF
--- a/src/Application/Players/Accounts/AccountComponent.cs
+++ b/src/Application/Players/Accounts/AccountComponent.cs
@@ -7,10 +7,15 @@ public class AccountComponent : Component
     public bool IsUnauthenticated => !IsAuthenticated;
     public void Authenticate() => IsAuthenticated = true;
 
-    public AccountComponent(PlayerInfo playerInfo, bool isAuthenticated = false)
+    public AccountComponent(PlayerInfo playerInfo, bool isAuthenticated)
     {
         ArgumentNullException.ThrowIfNull(playerInfo);
         PlayerInfo = playerInfo;
         IsAuthenticated = isAuthenticated;
+    }
+
+    public AccountComponent(PlayerInfo playerInfo) 
+        : this(playerInfo, isAuthenticated: false)
+    {
     }
 }

--- a/src/Application/Players/Accounts/AccountComponent.cs
+++ b/src/Application/Players/Accounts/AccountComponent.cs
@@ -3,9 +3,11 @@
 public class AccountComponent : Component
 {
     public PlayerInfo PlayerInfo { get; }
-    public bool IsAuthenticated { get; }
+    public bool IsAuthenticated { get; private set; }
     public bool IsUnauthenticated => !IsAuthenticated;
-    public AccountComponent(PlayerInfo playerInfo, bool isAuthenticated)
+    public void Authenticate() => IsAuthenticated = true;
+
+    public AccountComponent(PlayerInfo playerInfo, bool isAuthenticated = false)
     {
         ArgumentNullException.ThrowIfNull(playerInfo);
         PlayerInfo = playerInfo;

--- a/src/Application/Players/Accounts/Services/LoginDialogViewer.cs
+++ b/src/Application/Players/Accounts/Services/LoginDialogViewer.cs
@@ -12,41 +12,40 @@ public class LoginDialogViewer(
         Button1 = "Accept"
     };
 
-    public async Task View(Player connectedPlayer, PlayerInfo connectedPlayerInfo)
+    public async Task View(Player player)
     {
-        InputDialogResponse response = await dialogService.ShowAsync(connectedPlayer, _loginDialog);
+        InputDialogResponse response = await dialogService.ShowAsync(player, _loginDialog);
         if (response.Response == DialogResponse.Disconnected)
             return;
 
         if (response.Response == DialogResponse.RightButtonOrCancel)
         {
-            await View(connectedPlayer, connectedPlayerInfo);
+            await View(player);
             return;
         }
 
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         var enteredPassword = response.InputText ?? string.Empty;
-        bool isWrongPassword = !passwordHasher.Verify(enteredPassword, passwordHash: connectedPlayerInfo.Password);
+        bool isWrongPassword = !passwordHasher.Verify(enteredPassword, passwordHash: playerInfo.Password);
         if (isWrongPassword)
         {
             const int MaxFailedAttempts = 4;
-            var failedAttemptCount = connectedPlayer.GetComponent<FailedAttemptCountComponent>()
-                ?? connectedPlayer.AddComponent<FailedAttemptCountComponent>();
+            var failedAttemptCount = player.GetComponent<FailedAttemptCountComponent>()
+                ?? player.AddComponent<FailedAttemptCountComponent>();
             failedAttemptCount.Value++;
             if (failedAttemptCount.Value == MaxFailedAttempts)
             {
-                connectedPlayer.Kick();
+                player.Kick();
                 return;
             }
-            connectedPlayer.SendClientMessage(Color.Red, Messages.WrongPassword);
-            await View(connectedPlayer, connectedPlayerInfo);
+            player.SendClientMessage(Color.Red, Messages.WrongPassword);
+            await View(player);
             return;
         }
 
-        bool isAuthenticated = true;
-        connectedPlayer.GetComponent<FailedAttemptCountComponent>()?.Destroy();
-        connectedPlayer.GetComponent<AccountComponent>().Destroy();
-        connectedPlayer.AddComponent<AccountComponent>(connectedPlayerInfo, isAuthenticated);
-        connectedPlayer.SendClientMessage(Color.Red, Messages.SuccessfulLogin);
+        player.GetComponent<FailedAttemptCountComponent>()?.Destroy();
+        player.GetComponent<AccountComponent>().Authenticate();
+        player.SendClientMessage(Color.Red, Messages.SuccessfulLogin);
     }
 
     private class FailedAttemptCountComponent : Component

--- a/src/Application/Players/Accounts/Services/SignupDialogViewer.cs
+++ b/src/Application/Players/Accounts/Services/SignupDialogViewer.cs
@@ -28,23 +28,21 @@ public class SignupDialogViewer(
         await CreatePlayerAccount(connectedPlayer, enteredPassword);
     }
 
-    private async Task CreatePlayerAccount(Player connectedPlayer, string enteredPassword)
+    private async Task CreatePlayerAccount(Player player, string enteredPassword)
     {
-        PlayerInfo playerInfo = connectedPlayer.GetRequiredInfo();
+        PlayerInfo playerInfo = player.GetRequiredInfo();
         Result passwordResult = playerInfo.SetPassword(enteredPassword);
         if (passwordResult.IsFailed)
         {
-            connectedPlayer.SendClientMessage(Color.Red, passwordResult.Message);
-            await View(connectedPlayer);
+            player.SendClientMessage(Color.Red, passwordResult.Message);
+            await View(player);
             return;
         }
-        
-        bool isAuthenticated = true;
-        connectedPlayer.GetComponent<AccountComponent>().Destroy();
-        connectedPlayer.AddComponent<AccountComponent>(playerInfo, isAuthenticated);
+
+        player.GetComponent<AccountComponent>().Authenticate();
         var message = Smart.Format(Messages.CreatePlayerAccount, new { Password = enteredPassword });
-        connectedPlayer.SendClientMessage(Color.Red, message);
-        playerInfo.SetName(connectedPlayer.Name);
+        player.SendClientMessage(Color.Red, message);
+        playerInfo.SetName(player.Name);
         playerRepository.Create(playerInfo);
     }
 }

--- a/src/Application/Players/Accounts/Systems/AccountSystem.cs
+++ b/src/Application/Players/Accounts/Systems/AccountSystem.cs
@@ -6,23 +6,26 @@ public class AccountSystem(
     SignupDialogViewer signupDialogViewer) : ISystem
 {
     [Event]
-    public async Task OnPlayerConnect(Player connectedPlayer)
+    public async Task OnPlayerConnect(Player player)
     {
-        AttachAccountComponent(connectedPlayer);
-        PlayerInfo playerInfo = playerRepository.GetOrDefault(connectedPlayer.Name);
-        if(playerInfo is null)
+        PlayerInfo playerInfo = playerRepository.GetOrDefault(player.Name);
+
+        if (playerInfo is null)
         {
-            await signupDialogViewer.View(connectedPlayer);
+            playerInfo = CreatePlayerInfo(player.Name);
+            player.AddComponent<AccountComponent>(playerInfo);
+            await signupDialogViewer.View(player);
             return;
         }
-        await loginDialogViewer.View(connectedPlayer, playerInfo);
+
+        player.AddComponent<AccountComponent>(playerInfo);
+        await loginDialogViewer.View(player);
     }
 
-    private static void AttachAccountComponent(Player player)
+    private static PlayerInfo CreatePlayerInfo(string name)
     {
         var playerInfo = new PlayerInfo();
-        bool isAuthenticated = false;
-        playerInfo.SetName(player.Name);
-        player.AddComponent<AccountComponent>(playerInfo, isAuthenticated);
+        playerInfo.SetName(name);
+        return playerInfo;
     }
 }


### PR DESCRIPTION
* Keep a single `AccountComponent` instance attached for the player's entire session instead of recreating it during login and signup.
* Introduce `AccountComponent.Authenticate()` to model authentication as an explicit domain operation, replacing the previous destroy-and-recreate component pattern.
* Simplify the dialog viewer API by requiring only the Player instance, since `PlayerInfo` is always available through the attached **AccountComponent**.
* Add a `PlayerInfo` constructor overload to `AccountComponent` for compatibility with `EntityManager.AddComponent<T>()`, while preserving the existing constructor for test scenarios.