### PR TITLE
fix(sqlite): restore REGEXP constraint for player names

### DIFF
--- a/scripts/sqlite/gamemode.sql
+++ b/scripts/sqlite/gamemode.sql
@@ -5,7 +5,8 @@ CREATE TABLE IF NOT EXISTS players (
   CHECK(
     TRIM(name) != '' AND 
     LENGTH(name) >= 3 AND 
-    LENGTH(name) <= 20
+    LENGTH(name) <= 20 AND
+    name REGEXP '^[0-9a-zA-Z\[\]\(\)\$\@._=]+$'
   ),
   password TEXT NOT NULL CHECK(TRIM(password) != ''),
   total_kills INTEGER NOT NULL CHECK(total_kills >= 0),


### PR DESCRIPTION
This constraint was previously removed due to an AccessViolationException in the 32-bit SQLite provider when evaluating user-defined REGEXP functions (see #200).

The project now targets the 64-bit OpenMP server and the issue is no longer reproducible, allowing the database-level validation to be safely restored.
