### PR TITLE
feat: make ACK limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,7 +92,7 @@ MaxPlayers=30
 LagCompMode=1
 # Maximum number of ACK packets accepted from a client per second.
 # Increase this value if players are disconnected while loading large maps.
-AcksLimit=3000
+AcksLimit=5000
 
 #
 # Docker

--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,9 @@ RconPassword=343433%%$%%
 MaxPlayers=30
 # Enables lag compensation.
 LagCompMode=1
+# Maximum number of ACK packets accepted from a client per second.
+# Increase this value if players are disconnected while loading large maps.
+AcksLimit=3000
 
 #
 # Docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,13 @@ echo "Starting entrypoint..."
 echo "LagCompMode=$LagCompMode"
 echo "MaxPlayers=$MaxPlayers"
 echo "Port=$Port"
+echo "AcksLimit=$AcksLimit"
 
 jq "
   .game.lag_compensation_mode = ${LagCompMode}
   | .max_players = ${MaxPlayers}
   | .network.port = ${Port}
+  | .network.acks_limit = ${AcksLimit}
   | .password = \"${ServerPassword}\"
   | .rcon.password = \"${RconPassword}\"
 " config.json > config.tmp


### PR DESCRIPTION
## Motivation

The default `acks_limit` value (3000) may be too restrictive for large maps with many objects and materials. Increase this value if clients are disconnected during map rotation.

## Changes

- Add the `AcksLimit` environment variable.
- Configure `network.acks_limit` from the container entrypoint.
- Document when to increase the limit for large maps.

Related to issue #231.