### PR TITLE
feat: add additional GunGame weapon progressions

### DIFF
--- a/src/Application/GunGames/GunGameSystem.cs
+++ b/src/Application/GunGames/GunGameSystem.cs
@@ -86,9 +86,9 @@ public class GunGameSystem(
             return;
         }
 
-        var dialog = new ListDialog("GunGame Mode", "Select", "Close");
+        var dialog = new ListDialog("Select a Weapon Progression", "Select", "Close");
         foreach (WeaponProgressionType type in Enum.GetValues<WeaponProgressionType>())
-            dialog.Add(type.ToString());
+            dialog.Add(type.GetDisplayName());
 
         ListDialogResponse response = await dialogService.ShowAsync(player, dialog);
         if (response.IsRightButtonOrDisconnected())

--- a/src/Application/GunGames/ServiceCollectionExtensions.cs
+++ b/src/Application/GunGames/ServiceCollectionExtensions.cs
@@ -7,11 +7,17 @@ public static class GunGameExtensions
         services
             .AddSingleton<GunGameReward>()
             .AddSingleton<GunGameSession>()
+            .AddSingleton<WeaponProgression>()
             .AddSingleton<IGunGameMode>(sp => sp.GetRequiredService<GunGameSystem>());
 
         services
             .AddSingleton<WeaponProgressionBase, ClassicWeaponProgression>()
-            .AddSingleton<WeaponProgression>()
+            .AddSingleton<WeaponProgressionBase, HardcoreWeaponProgression>()
+            .AddSingleton<WeaponProgressionBase, PistolsWeaponProgression>()
+            .AddSingleton<WeaponProgressionBase, ReverseClassicWeaponProgression>()
+            .AddSingleton<WeaponProgressionBase, RiflesWeaponProgression>()
+            .AddSingleton<WeaponProgressionBase, ShotgunsWeaponProgression>()
+            .AddSingleton<WeaponProgressionBase, SmgsWeaponProgression>()
             .AddSingleton<IDictionary<WeaponProgressionType, WeaponProgressionBase>>(sp =>
             {
                 var progressions = sp.GetRequiredService<IEnumerable<WeaponProgressionBase>>();

--- a/src/Application/GunGames/WeaponProgressions/Definitions/HardcoreWeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/Definitions/HardcoreWeaponProgression.cs
@@ -1,0 +1,23 @@
+﻿namespace CTF.Application.GunGames.WeaponProgressions.Definitions;
+
+/// <summary>
+/// Defines a GunGame weapon progression using only high-skill weapons.
+/// </summary>
+public class HardcoreWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.Hardcore;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.Deagle,
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.Deagle,
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/src/Application/GunGames/WeaponProgressions/Definitions/PistolsWeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/Definitions/PistolsWeaponProgression.cs
@@ -1,0 +1,26 @@
+﻿namespace CTF.Application.GunGames.WeaponProgressions.Definitions;
+
+/// <summary>
+/// Defines a GunGame weapon progression using only pistols.
+/// </summary>
+public class PistolsWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.Pistols;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.Silenced,
+            WeaponDefinitions.Colt45,
+            WeaponDefinitions.Deagle,
+            WeaponDefinitions.Silenced,
+            WeaponDefinitions.Colt45,
+            WeaponDefinitions.Deagle,
+            WeaponDefinitions.Silenced,
+            WeaponDefinitions.Colt45,
+            WeaponDefinitions.Deagle,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/src/Application/GunGames/WeaponProgressions/Definitions/ReverseClassicWeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/Definitions/ReverseClassicWeaponProgression.cs
@@ -1,0 +1,32 @@
+﻿namespace CTF.Application.GunGames.WeaponProgressions.Definitions;
+
+/// <summary>
+/// Defines the reverse of the classic GunGame weapon progression.
+/// Players begin with the most difficult weapons and finish with the easiest,
+/// before reaching the final knife level.
+/// </summary>
+public class ReverseClassicWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.ReverseClassic;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.Deagle,
+            WeaponDefinitions.M4,
+            WeaponDefinitions.AK47,
+            WeaponDefinitions.MP5,
+            WeaponDefinitions.Uzi,
+            WeaponDefinitions.Tec9,
+            WeaponDefinitions.CombatShotgun,
+            WeaponDefinitions.Sawedoff,
+            WeaponDefinitions.Shotgun,
+            WeaponDefinitions.Colt45,
+            WeaponDefinitions.Silenced,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/src/Application/GunGames/WeaponProgressions/Definitions/RiflesWeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/Definitions/RiflesWeaponProgression.cs
@@ -1,0 +1,25 @@
+﻿namespace CTF.Application.GunGames.WeaponProgressions.Definitions;
+
+/// <summary>
+/// Defines a GunGame weapon progression using only rifles.
+/// </summary>
+public class RiflesWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.Rifles;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.CountryRifle,
+            WeaponDefinitions.SniperRifle,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/src/Application/GunGames/WeaponProgressions/Definitions/ShotgunsWeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/Definitions/ShotgunsWeaponProgression.cs
@@ -1,0 +1,26 @@
+﻿namespace CTF.Application.GunGames.WeaponProgressions.Definitions;
+
+/// <summary>
+/// Defines a GunGame weapon progression using only shotguns.
+/// </summary>
+public class ShotgunsWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.Shotguns;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.Shotgun,
+            WeaponDefinitions.Sawedoff,
+            WeaponDefinitions.CombatShotgun,
+            WeaponDefinitions.Shotgun,
+            WeaponDefinitions.Sawedoff,
+            WeaponDefinitions.CombatShotgun,
+            WeaponDefinitions.Shotgun,
+            WeaponDefinitions.Sawedoff,
+            WeaponDefinitions.CombatShotgun,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/src/Application/GunGames/WeaponProgressions/Definitions/SmgsWeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/Definitions/SmgsWeaponProgression.cs
@@ -1,0 +1,26 @@
+﻿namespace CTF.Application.GunGames.WeaponProgressions.Definitions;
+
+/// <summary>
+/// Defines a GunGame weapon progression using only submachine guns.
+/// </summary>
+public class SmgsWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.SMGs;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.Tec9,
+            WeaponDefinitions.Uzi,
+            WeaponDefinitions.MP5,
+            WeaponDefinitions.Tec9,
+            WeaponDefinitions.Uzi,
+            WeaponDefinitions.MP5,
+            WeaponDefinitions.Tec9,
+            WeaponDefinitions.Uzi,
+            WeaponDefinitions.MP5,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/src/Application/GunGames/WeaponProgressions/WeaponProgressionType.cs
+++ b/src/Application/GunGames/WeaponProgressions/WeaponProgressionType.cs
@@ -5,8 +5,24 @@
 /// </summary>
 public enum WeaponProgressionType
 {
-    /// <summary>
-    /// The default GunGame weapon progression.
-    /// </summary>
-    Classic
+    [DisplayName("Classic")]
+    Classic,
+
+    [DisplayName("Reverse Classic")]
+    ReverseClassic,
+
+    [DisplayName("Pistols Only")]
+    Pistols,
+
+    [DisplayName("SMGs Only")]
+    SMGs,
+
+    [DisplayName("Shotguns Only")]
+    Shotguns,
+
+    [DisplayName("Rifles Only")]
+    Rifles,
+
+    [DisplayName("Hardcore")]
+    Hardcore
 }


### PR DESCRIPTION
Adds several new weapon progression presets for GunGame.

New progressions:

- Reverse Classic
- Pistols Only
- SMGs Only
- Shotguns Only
- Rifles Only
- Hardcore

Also updates the weapon progression selection dialog to display user-friendly names using the `DisplayName` attribute.