### PR TITLE
feat: enforce GunGame weapon progression

### DIFF
--- a/src/Application/GunGames/GunGameWeaponEnforcer.cs
+++ b/src/Application/GunGames/GunGameWeaponEnforcer.cs
@@ -1,0 +1,33 @@
+﻿using SampSharp.OpenMp.Core.Std.Chrono;
+
+namespace CTF.Application.GunGames;
+
+/// <summary>
+/// Ensures that players can only use the weapon assigned to their current
+/// GunGame level while the mode is active.
+/// </summary>
+public class GunGameWeaponEnforcer(
+    IGunGameMode gunGameMode,
+    WeaponProgression weaponProgression) : ISystem
+{
+    [Event]
+    public void OnPlayerUpdate(Player player, TimePoint _)
+    {
+        if (!gunGameMode.IsEnabled)
+            return;
+
+        Weapon currentWeapon = player.Weapon;
+        if (currentWeapon == Weapon.None || currentWeapon == Weapon.Knife)
+            return;
+
+        var playerProgression = player.GetComponent<PlayerProgression>();
+        Weapon expectedWeapon = weaponProgression.GetWeapon(playerProgression.WeaponLevel).Id;
+
+        if (currentWeapon == expectedWeapon)
+            return;
+
+        player.ResetWeapons();
+        player.GiveWeapon(Weapon.Knife, 1);
+        player.GiveWeapon(expectedWeapon, IWeapon.UnlimitedAmmo);
+    }
+}


### PR DESCRIPTION
Adds a weapon enforcement system that ensures players can only use the weapon assigned to their current GunGame level while the mode is active.

This prevents weapon progression from being bypassed by weapon dialogs, admin commands, or external modifications (e.g. hacks), preserving the integrity of the GunGame session.