### PR TITLE
refactor: standardize gameplay reward definitions

### DIFF
--- a/src/Application/GunGames/GunGameReward.cs
+++ b/src/Application/GunGames/GunGameReward.cs
@@ -2,13 +2,13 @@
 
 public class GunGameReward(PlayerStatsRenderer playerStatsRenderer)
 {
-    private const int WinnerHealth = 100;
-    private const int WinnerArmour = 100;
-    private const int WinnerCoins  = 100;
-    private const int TeamHealth   = 50;
-    private const int TeamArmour   = 50;
-    private const int TeamCoins    = 15;
-    private const int TeamScore    = 3;
+    private const int WinnerEarnedHealth = 100;
+    private const int WinnerEarnedArmour = 100;
+    private const int WinnerEarnedCoins  = 100;
+    private const int TeamEarnedHealth   = 50;
+    private const int TeamEarnedArmour   = 50;
+    private const int TeamEarnedCoins    = 15;
+    private const int TeamEarnedScore    = 3;
     private readonly record struct WeaponReward(IWeapon Weapon, int Ammo);
     private readonly WeaponReward[] _weaponRewards = 
     [
@@ -23,14 +23,14 @@ public class GunGameReward(PlayerStatsRenderer playerStatsRenderer)
         var weaponReward = _weaponRewards[Random.Shared.Next(_weaponRewards.Length)];
         var winnerRewardSummary = Smart.Format(GunGameMessages.WinnerRewardSummary, new
         {
-            Rewards = $"+{WinnerHealth} Health, +{WinnerArmour} Armour, " +
-                      $"+{WinnerCoins} Coins, +{weaponReward.Weapon.Name}"
+            Rewards = $"+{WinnerEarnedHealth} Health, +{WinnerEarnedArmour} Armour, " +
+                      $"+{WinnerEarnedCoins} Coins, +{weaponReward.Weapon.Name}"
         });
         PlayerInfo winnerInfo = winner.GetRequiredInfo();
-        winner.AddHealth(WinnerHealth);
-        winner.AddArmour(WinnerArmour);
+        winner.AddHealth(WinnerEarnedHealth);
+        winner.AddArmour(WinnerEarnedArmour);
         winner.GiveWeapon(weaponReward.Weapon.Id, weaponReward.Ammo);
-        winnerInfo.StatsPerRound.AddCoins(WinnerCoins);
+        winnerInfo.StatsPerRound.AddCoins(WinnerEarnedCoins);
         playerStatsRenderer.UpdateTextDraw(winner);
 
         winner.SendClientMessage(Color.Yellow, GunGameMessages.WinnerRewardGranted);
@@ -45,8 +45,8 @@ public class GunGameReward(PlayerStatsRenderer playerStatsRenderer)
         var teamRewardSummary = Smart.Format(GunGameMessages.TeamRewardSummary, new
         {
             Team = winnerInfo.Team.Name,
-            Rewards = $"+{TeamHealth} Health, +{TeamArmour} Armour, " +
-                      $"+{TeamCoins} Coins, +{TeamScore} Score"
+            Rewards = $"+{TeamEarnedHealth} Health, +{TeamEarnedArmour} Armour, " +
+                      $"+{TeamEarnedCoins} Coins, +{TeamEarnedScore} Score"
         });
 
         foreach (Player teammate in winnerInfo.Team.Members)
@@ -55,10 +55,10 @@ public class GunGameReward(PlayerStatsRenderer playerStatsRenderer)
                 continue;
 
             PlayerInfo teammateInfo = teammate.GetRequiredInfo();
-            teammate.AddHealth(TeamHealth);
-            teammate.AddArmour(TeamArmour);
-            teammate.AddScore(TeamScore);
-            teammateInfo.StatsPerRound.AddCoins(TeamCoins);
+            teammate.AddHealth(TeamEarnedHealth);
+            teammate.AddArmour(TeamEarnedArmour);
+            teammate.AddScore(TeamEarnedScore);
+            teammateInfo.StatsPerRound.AddCoins(TeamEarnedCoins);
             playerStatsRenderer.UpdateTextDraw(teammate);
 
             teammate.SendClientMessage(Color.LightGreen, teamRewardGranted);

--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -943,11 +943,20 @@ namespace CTF.Application {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have gained +100 coins, +100 armour, and +100 health.
+        ///   Looks up a localized string similar to You have received the following rank-up rewards:.
         /// </summary>
-        internal static string RankUpAward {
+        internal static string RankUpAwardGranted {
             get {
-                return ResourceManager.GetString("RankUpAward", resourceCulture);
+                return ResourceManager.GetString("RankUpAwardGranted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to +{Health} Health, +{Armour} Armour, +{Coins} Coins.
+        /// </summary>
+        internal static string RankUpAwardSummary {
+            get {
+                return ResourceManager.GetString("RankUpAwardSummary", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -402,8 +402,8 @@
   <data name="PromotedToRole" xml:space="preserve">
     <value>Promoted to {RoleName} role</value>
   </data>
-  <data name="RankUpAward" xml:space="preserve">
-    <value>You have gained +100 coins, +100 armour, and +100 health</value>
+  <data name="RankUpAwardGranted" xml:space="preserve">
+    <value>You have received the following rank-up rewards:</value>
   </data>
   <data name="ReceiveArmourFromPlayer" xml:space="preserve">
     <value>Congratulations! You've received {Armour}% armour from {PlayerName}!</value>
@@ -563,5 +563,8 @@
   </data>
   <data name="CombosUnavailable" xml:space="preserve">
     <value>Combos are unavailable while GunGame mode is active.</value>
+  </data>
+  <data name="RankUpAwardSummary" xml:space="preserve">
+    <value>+{Health} Health, +{Armour} Armour, +{Coins} Coins</value>
   </data>
 </root>

--- a/src/Application/Players/Accounts/Services/KillingSpreeUpdater.cs
+++ b/src/Application/Players/Accounts/Services/KillingSpreeUpdater.cs
@@ -7,6 +7,8 @@ public class KillingSpreeUpdater(
 {
     private const int MinimumKillingSpree = 2;
     private const int EarnedCoins = 20;
+    private const int EarnedHealth = 10;
+    private const int ConsecutiveKillsBonusHealth = 40;
 
     public void Update(Player player)
     {
@@ -28,7 +30,7 @@ public class KillingSpreeUpdater(
 
         player.GameText($"KILL X{currentKillingSpree}", TimeSpan.FromSeconds(3), GameTextStyle.Style3);
         playerInfo.StatsPerRound.AddCoins(EarnedCoins);
-        player.AddHealth(10);
+        player.AddHealth(EarnedHealth);
 
         if (currentKillingSpree % 3 == 0)
         {
@@ -41,7 +43,7 @@ public class KillingSpreeUpdater(
             // Sample Message:
             // Dave has had 3 consecutive kills without dying.
             worldService.SendClientMessage(Color.Orange, message);
-            player.AddHealth(40);
+            player.AddHealth(ConsecutiveKillsBonusHealth);
         }
     }
 }

--- a/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
+++ b/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
@@ -4,6 +4,10 @@ public class PlayerRankUpdater(
     IPlayerRepository playerRepository,
     IGunGameMode gunGameMode)
 {
+    private const int EarnedHealth = 100;
+    private const int EarnedArmour = 100;
+    private const int EarnedCoins  = 100;
+
     public void Update(Player player)
     {
         PlayerInfo playerInfo = player.GetRequiredInfo();
@@ -30,6 +34,15 @@ public class PlayerRankUpdater(
         player.Armour = 100;
         player.Health = 100;
         playerInfo.StatsPerRound.AddCoins(100);
-        player.SendClientMessage(Color.Orange, Messages.RankUpAward);
+
+        var rankUpAwardSummary = Smart.Format(Messages.RankUpAwardSummary, new
+        {
+            Health = EarnedHealth,
+            Armour = EarnedArmour,
+            Coins  = EarnedCoins
+        });
+
+        player.SendClientMessage(Color.Orange, Messages.RankUpAwardGranted);
+        player.SendClientMessage(Color.Orange, rankUpAwardSummary);
     }
 }

--- a/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
+++ b/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
@@ -31,9 +31,9 @@ public class PlayerRankUpdater(
         if (gunGameMode.IsEnabled)
             return;
 
-        player.Armour = 100;
-        player.Health = 100;
-        playerInfo.StatsPerRound.AddCoins(100);
+        player.Armour = EarnedHealth;
+        player.Health = EarnedArmour;
+        playerInfo.StatsPerRound.AddCoins(EarnedCoins);
 
         var rankUpAwardSummary = Smart.Format(Messages.RankUpAwardSummary, new
         {

--- a/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
+++ b/src/Application/Players/Accounts/Services/PlayerRankUpdater.cs
@@ -31,8 +31,8 @@ public class PlayerRankUpdater(
         if (gunGameMode.IsEnabled)
             return;
 
-        player.Armour = EarnedHealth;
-        player.Health = EarnedArmour;
+        player.Armour = EarnedArmour;
+        player.Health = EarnedHealth;
         playerInfo.StatsPerRound.AddCoins(EarnedCoins);
 
         var rankUpAwardSummary = Smart.Format(Messages.RankUpAwardSummary, new

--- a/src/Application/Players/Combos/Definitions/FlamethrowerVitality.cs
+++ b/src/Application/Players/Combos/Definitions/FlamethrowerVitality.cs
@@ -2,17 +2,20 @@
 
 public class FlamethrowerVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and FlameThrower";
+    private const int Health = 100;
+    private const int Armour = 100;
+    // 1000 (shows in game as 50-50).
+    private const int FlamethrowerAmmo = 1000;
+
+    public string Name => $"{Health} Health, {Armour} Armour and FlameThrower";
     public int RequiredCoins => 100;
 
     public Result Give(Player player)
     {
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        player.Health = 100;
-        player.Armour = 100;
-        // 1000 (shows in game as 50-50).
-        const int ammo = 1000;
-        player.GiveWeapon(Weapon.FlameThrower, ammo);
+        player.Health = Health;
+        player.Armour = Armour;
+        player.GiveWeapon(Weapon.FlameThrower, FlamethrowerAmmo);
         playerInfo.StatsPerRound.ResetCoins();
         return Result.Success();
     }

--- a/src/Application/Players/Combos/Definitions/GrenadesVitality.cs
+++ b/src/Application/Players/Combos/Definitions/GrenadesVitality.cs
@@ -2,15 +2,19 @@
 
 public class GrenadesVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and Grenades";
+    private const int Health = 100;
+    private const int Armour = 100;
+    private const int GrenadeAmmo = 6;
+
+    public string Name => $"{Health} Health, {Armour} Armour and Grenades";
     public int RequiredCoins => 100;
 
     public Result Give(Player player)
     {
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        player.Health = 100;
-        player.Armour = 100;
-        player.GiveWeapon(Weapon.Grenade, ammo: 6);
+        player.Health = Health;
+        player.Armour = Armour;
+        player.GiveWeapon(Weapon.Grenade, GrenadeAmmo);
         playerInfo.StatsPerRound.ResetCoins();
         return Result.Success();
     }

--- a/src/Application/Players/Combos/Definitions/MolotovVitality.cs
+++ b/src/Application/Players/Combos/Definitions/MolotovVitality.cs
@@ -2,15 +2,19 @@
 
 public class MolotovVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and Molotov cocktail";
+    private const int Health = 100;
+    private const int Armour = 100;
+    private const int MolotovAmmo = 6;
+
+    public string Name => $"{Health} Health, {Armour} Armour and Molotov cocktail";
     public int RequiredCoins => 100;
 
     public Result Give(Player player)
     {
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        player.Health = 100;
-        player.Armour = 100;
-        player.GiveWeapon(Weapon.Moltov, ammo: 6);
+        player.Health = Health;
+        player.Armour = Armour;
+        player.GiveWeapon(Weapon.Moltov, MolotovAmmo);
         playerInfo.StatsPerRound.ResetCoins();
         return Result.Success();
     }

--- a/src/Application/Players/Combos/Definitions/RocketLauncherVitality.cs
+++ b/src/Application/Players/Combos/Definitions/RocketLauncherVitality.cs
@@ -2,7 +2,10 @@
 
 public class RocketLauncherVitality(ComboSettings comboSettings) : ICombo
 {
-    public string Name => "100 Health and Rocket launcher(RPG)";
+    private const int Health = 100;
+    private const int RocketLauncherAmmo = 2;
+
+    public string Name => $"{Health} Health and Rocket launcher(RPG)";
     public int RequiredCoins => 100;
 
     public Result Give(Player player)
@@ -14,8 +17,8 @@ public class RocketLauncherVitality(ComboSettings comboSettings) : ICombo
         }
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        player.Health = 100;
-        player.GiveWeapon(Weapon.RocketLauncher, ammo: 2);
+        player.Health = Health;
+        player.GiveWeapon(Weapon.RocketLauncher, RocketLauncherAmmo);
         playerInfo.StatsPerRound.ResetCoins();
         return Result.Success();
     }

--- a/src/Application/Players/Combos/Definitions/SatchelChargesVitality.cs
+++ b/src/Application/Players/Combos/Definitions/SatchelChargesVitality.cs
@@ -2,16 +2,20 @@
 
 public class SatchelChargesVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and Satchel charges";
+    private const int Health = 100;
+    private const int Armour = 100;
+    private const int SatchelAmmo = 6;
+
+    public string Name => $"{Health} Health, {Armour} Armour and Satchel charges";
     public int RequiredCoins => 100;
 
     public Result Give(Player player)
     {
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        player.Health = 100;
-        player.Armour = 100;
-        player.GiveWeapon(Weapon.SatchelCharge, ammo: 6);
-        player.GiveWeapon(Weapon.Detonator, ammo: 1);
+        player.Health = Health;
+        player.Armour = Armour;
+        player.GiveWeapon(Weapon.SatchelCharge, SatchelAmmo);
+        player.GiveWeapon(Weapon.Detonator, 1);
         playerInfo.StatsPerRound.ResetCoins();
         return Result.Success();
     }

--- a/src/Application/Players/Combos/Definitions/TearGasVitality.cs
+++ b/src/Application/Players/Combos/Definitions/TearGasVitality.cs
@@ -2,15 +2,19 @@
 
 public class TearGasVitality : ICombo
 {
-    public string Name => "100 Health, 100 Armour and Tear gas";
+    private const int Health = 100;
+    private const int Armour = 100;
+    private const int TearGasAmmo = 30;
+
+    public string Name => $"{Health} Health, {Armour} Armour and Tear gas";
     public int RequiredCoins => 100;
 
     public Result Give(Player player)
     {
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        player.Health = 100;
-        player.Armour = 100;
-        player.GiveWeapon(Weapon.Teargas, ammo: 30);
+        player.Health = Health;
+        player.Armour = Armour;
+        player.GiveWeapon(Weapon.Teargas, TearGasAmmo);
         playerInfo.StatsPerRound.ResetCoins();
         return Result.Success();
     }

--- a/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
@@ -11,6 +11,9 @@ public class OnFlagCaptured(
     PlayerStatsRenderer playerStatsRenderer,
     FlagCarrierSettings flagCarrierSettings) : IFlagEvent
 {
+    private const int EarnedCoins = 5;
+    private const int EarnedScore = 2;
+
     public FlagStatus FlagStatus => FlagStatus.Captured;
 
     public void Handle(Team team, Player player)
@@ -28,9 +31,9 @@ public class OnFlagCaptured(
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag captured!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        playerInfo.StatsPerRound.AddCoins(5);
+        playerInfo.StatsPerRound.AddCoins(EarnedCoins);
         playerInfo.AddCapturedFlags();
-        player.AddScore(2);
+        player.AddScore(EarnedScore);
         if (flagCarrierSettings.ShowOnRadarMap)
         {
             player.ShowOnRadarMap();

--- a/src/Application/Teams/Flags/Events/OnFlagReturned.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagReturned.cs
@@ -11,6 +11,9 @@ public class OnFlagReturned(
     PlayerStatsRenderer playerStatsRenderer,
     FlagAutoReturnTimer flagAutoReturnTimer) : IFlagEvent
 {
+    private const int EarnedCoins = 5;
+    private const int EarnedScore = 2;
+
     public FlagStatus FlagStatus => FlagStatus.Returned;
 
     public void Handle(Team team, Player player)
@@ -29,9 +32,9 @@ public class OnFlagReturned(
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        playerInfo.StatsPerRound.AddCoins(5);
+        playerInfo.StatsPerRound.AddCoins(EarnedCoins);
         playerInfo.AddReturnedFlags();
-        player.AddScore(2);
+        player.AddScore(EarnedScore);
         playerRepository.UpdateReturnedFlags(playerInfo);
         playerStatsRenderer.UpdateTextDraw(player);
     }

--- a/src/Application/Teams/Flags/Events/OnFlagScore.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagScore.cs
@@ -11,6 +11,12 @@ public class OnFlagScore(
     TeamTextDrawRenderer teamTextDrawRenderer,
     PlayerStatsRenderer playerStatsRenderer) : IFlagEvent
 {
+    private const int CarrierEarnedCoins = 8;
+    private const int CarrierEarnedScore = 4;
+    private const int TeamEarnedCoins    = 5;
+    private const int TeamEarnedHealth   = 10;
+    private const int TeamEarnedScore    = 1;
+
     public FlagStatus FlagStatus => FlagStatus.Brought;
 
     public void Handle(Team team, Player player)
@@ -30,9 +36,9 @@ public class OnFlagScore(
         worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} team scores!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
-        playerInfo.StatsPerRound.AddCoins(8);
+        playerInfo.StatsPerRound.AddCoins(CarrierEarnedCoins);
         playerInfo.AddBroughtFlags();
-        player.AddScore(4);
+        player.AddScore(CarrierEarnedScore);
         player.HideOnRadarMap();
         playerRepository.UpdateBroughtFlags(playerInfo);
         GiveRewards(team);
@@ -44,9 +50,9 @@ public class OnFlagScore(
         foreach (Player player in teamMembers)
         {
             PlayerInfo playerInfo = player.GetRequiredInfo();
-            playerInfo.StatsPerRound.AddCoins(5);
-            player.AddHealth(10);
-            player.AddScore(1);
+            playerInfo.StatsPerRound.AddCoins(TeamEarnedCoins);
+            player.AddHealth(TeamEarnedHealth);
+            player.AddScore(TeamEarnedScore);
             playerStatsRenderer.UpdateTextDraw(player);
         }
     }


### PR DESCRIPTION
Standardize gameplay reward definitions across the project.

* Replace magic numbers with named constants.
* Adopt a consistent Earned* naming convention.
* Reuse reward constants when formatting player messages.