### PR TITLE
test: add domain tests for GunGame mode

### DIFF
--- a/tests/Application.Tests/GunGames/KillsRequiredPerLevelTests.cs
+++ b/tests/Application.Tests/GunGames/KillsRequiredPerLevelTests.cs
@@ -1,0 +1,30 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class KillsRequiredPerLevelTests
+{
+    [Test]
+    public void Constructor_WhenValueIsGreaterThanZero_ShouldCreateKillsRequiredPerLevel()
+    {
+        // Arrange
+        const int expectedValue = 2;
+
+        // Act
+        var killsRequired = new KillsRequiredPerLevel(expectedValue);
+
+        // Assert
+        killsRequired.Value.Should().Be(expectedValue);
+    }
+
+    [Test]
+    public void Constructor_WhenValueIsLessThanOne_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        const int invalidValue = 0;
+
+        // Act
+        Action act = () => _ = new KillsRequiredPerLevel(invalidValue);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Application.Tests/GunGames/MaxWeaponLevelTests.cs
+++ b/tests/Application.Tests/GunGames/MaxWeaponLevelTests.cs
@@ -1,0 +1,30 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class MaxWeaponLevelTests
+{
+    [Test]
+    public void Constructor_WhenValueIsGreaterThanZero_ShouldCreateMaxWeaponLevel()
+    {
+        // Arrange
+        const int expectedValue = 5;
+
+        // Act
+        var maxWeaponLevel = new MaxWeaponLevel(expectedValue);
+
+        // Assert
+        maxWeaponLevel.Value.Should().Be(expectedValue);
+    }
+
+    [Test]
+    public void Constructor_WhenValueIsLessThanOne_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        const int invalidValue = 0;
+
+        // Act
+        Action act = () => _ = new MaxWeaponLevel(invalidValue);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Application.Tests/GunGames/PlayerProgressionTests.cs
+++ b/tests/Application.Tests/GunGames/PlayerProgressionTests.cs
@@ -1,0 +1,194 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class PlayerProgressionTests
+{
+    private readonly MaxWeaponLevel _maxLevel = new(4);
+
+    [Test]
+    public void PlayerProgression_WhenCreated_ShouldStartAtFirstWeaponLevel()
+    {
+        // Arrange
+
+        // Act
+        var progression = new PlayerProgression();
+
+        // Assert
+        progression.WeaponLevel.Should().Be(WeaponLevel.First);
+        progression.KillsTowardsNextLevel.Should().Be(0);
+    }
+
+    [Test]
+    public void AddKillsTowardsNextLevel_WhenInvoked_ShouldIncreaseKillsTowardsNextLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        // Act
+        progression.AddKillsTowardsNextLevel();
+
+        // Assert
+        progression.KillsTowardsNextLevel.Should().Be(1);
+    }
+
+    [Test]
+    public void CanLevelUp_WhenRequiredKillsHaveNotBeenReached_ShouldReturnFalse()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+        var requiredKills = new KillsRequiredPerLevel(2);
+
+        progression.AddKillsTowardsNextLevel();
+
+        // Act
+        bool canLevelUp = progression.CanLevelUp(requiredKills);
+
+        // Assert
+        canLevelUp.Should().BeFalse();
+    }
+
+    [Test]
+    public void CanLevelUp_WhenRequiredKillsAreReached_ShouldReturnTrue()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+        var requiredKills = new KillsRequiredPerLevel(2);
+
+        progression.AddKillsTowardsNextLevel();
+        progression.AddKillsTowardsNextLevel();
+
+        // Act
+        bool canLevelUp = progression.CanLevelUp(requiredKills);
+
+        // Assert
+        canLevelUp.Should().BeTrue();
+    }
+
+    [Test]
+    public void CanLevelUp_WhenRequiredKillsHaveBeenExceeded_ShouldReturnTrue()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+        var requiredKills = new KillsRequiredPerLevel(2);
+
+        progression.AddKillsTowardsNextLevel();
+        progression.AddKillsTowardsNextLevel();
+        progression.AddKillsTowardsNextLevel();
+
+        // Act
+        bool canLevelUp = progression.CanLevelUp(requiredKills);
+
+        // Assert
+        canLevelUp.Should().BeTrue();
+    }
+
+    [Test]
+    public void LevelUp_WhenPlayerIsBelowMaxLevel_ShouldAdvanceToNextLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        // Act
+        progression.LevelUp(_maxLevel);
+
+        // Assert
+        progression.WeaponLevel.Value.Should().Be(2);
+    }
+
+    [Test]
+    public void LevelUp_WhenPlayerIsAtMaxLevel_ShouldRemainAtMaxLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        progression.LevelUp(_maxLevel);
+        progression.LevelUp(_maxLevel);
+        progression.LevelUp(_maxLevel);
+
+        // Act
+        progression.LevelUp(_maxLevel);
+
+        // Assert
+        progression.WeaponLevel.Value.Should().Be(_maxLevel.Value);
+    }
+
+    [Test]
+    public void LevelUp_WhenInvoked_ShouldResetKillsTowardsNextLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        progression.AddKillsTowardsNextLevel();
+        progression.AddKillsTowardsNextLevel();
+
+        // Act
+        progression.LevelUp(_maxLevel);
+
+        // Assert
+        progression.KillsTowardsNextLevel.Should().Be(0);
+    }
+
+    [Test]
+    public void LevelDown_WhenPlayerIsAboveFirstLevel_ShouldMoveToPreviousLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        progression.LevelUp(_maxLevel);
+        progression.LevelUp(_maxLevel);
+
+        // Act
+        progression.LevelDown();
+
+        // Assert
+        progression.WeaponLevel.Value.Should().Be(2);
+    }
+
+    [Test]
+    public void LevelDown_WhenPlayerIsAtFirstLevel_ShouldRemainAtFirstLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        // Act
+        progression.LevelDown();
+
+        // Assert
+        progression.WeaponLevel.Should().Be(WeaponLevel.First);
+    }
+
+    [Test]
+    public void LevelDown_WhenInvoked_ShouldResetKillsTowardsNextLevel()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        progression.LevelUp(_maxLevel);
+        progression.AddKillsTowardsNextLevel();
+        progression.AddKillsTowardsNextLevel();
+
+        // Act
+        progression.LevelDown();
+
+        // Assert
+        progression.KillsTowardsNextLevel.Should().Be(0);
+    }
+
+    [Test]
+    public void Reset_WhenInvoked_ShouldRestoreInitialProgression()
+    {
+        // Arrange
+        var progression = new PlayerProgression();
+
+        progression.LevelUp(_maxLevel);
+        progression.LevelUp(_maxLevel);
+        progression.AddKillsTowardsNextLevel();
+        progression.AddKillsTowardsNextLevel();
+
+        // Act
+        progression.Reset();
+
+        // Assert
+        progression.WeaponLevel.Should().Be(WeaponLevel.First);
+        progression.KillsTowardsNextLevel.Should().Be(0);
+    }
+}

--- a/tests/Application.Tests/GunGames/ProcessKillTests.cs
+++ b/tests/Application.Tests/GunGames/ProcessKillTests.cs
@@ -42,6 +42,7 @@ public class ProcessKillTests
         // Assert
         result.Should().Be(GunGameResult.ScoredFinalKill);
         killer.WeaponLevel.Value.Should().Be(_maxLevel.Value);
+        killer.KillsTowardsNextLevel.Should().Be(0);
         victim.WeaponLevel.Should().Be(WeaponLevel.First);
     }
 
@@ -157,5 +158,42 @@ public class ProcessKillTests
         result.Should().Be(GunGameResult.ReachedFinalLevel);
         killer.WeaponLevel.Value.Should().Be(_maxLevel.Value);
         killer.KillsTowardsNextLevel.Should().Be(0);
+    }
+
+    [Test]
+    public void ProcessKill_WhenPlayerAtFinalLevelKillsWithNonKnifeFinalWeapon_ShouldReturnScoredFinalKill()
+    {
+        // Arrange
+        var session = new GunGameSession
+        {
+            WeaponProgressionType = WeaponProgressionType.Classic,
+            KillsRequiredPerLevel = new KillsRequiredPerLevel(2)
+        };
+
+        var progressions = new Dictionary<WeaponProgressionType, WeaponProgressionBase>
+        {
+            [WeaponProgressionType.Classic] = new NonKnifeFinalWeaponProgression()
+        };
+
+        var weaponProgression = new WeaponProgression(session, progressions);
+        var gunGame = new GunGame(weaponProgression, session.KillsRequiredPerLevel);
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+
+        MaxWeaponLevel maxLevel = weaponProgression.MaxLevel;
+        Weapon finalLevelWeapon = Weapon.Minigun;
+
+        killer.LevelUp(maxLevel);
+        killer.LevelUp(maxLevel);
+        killer.LevelUp(maxLevel);
+
+        // Act
+        GunGameResult result = gunGame.ProcessKill(killer, victim, finalLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.ScoredFinalKill);
+        killer.WeaponLevel.Value.Should().Be(maxLevel.Value);
+        killer.KillsTowardsNextLevel.Should().Be(0);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
     }
 }

--- a/tests/Application.Tests/GunGames/ProcessKillTests.cs
+++ b/tests/Application.Tests/GunGames/ProcessKillTests.cs
@@ -1,0 +1,161 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class ProcessKillTests
+{
+    private GunGame _gunGame;
+    private MaxWeaponLevel _maxLevel;
+
+    [SetUp]
+    public void Init()
+    {
+        var session = new GunGameSession
+        {
+            WeaponProgressionType = WeaponProgressionType.Classic,
+            KillsRequiredPerLevel = new KillsRequiredPerLevel(2)
+        };
+
+        var progressions = new Dictionary<WeaponProgressionType, WeaponProgressionBase>
+        {
+            [WeaponProgressionType.Classic] = new TestWeaponProgression()
+        };
+
+        var weaponProgression = new WeaponProgression(session, progressions);
+        _gunGame = new GunGame(weaponProgression, session.KillsRequiredPerLevel);
+        _maxLevel = weaponProgression.MaxLevel;
+    }
+
+    [Test]
+    public void ProcessKill_WhenPlayerAtMaxLevelKillsWithKnife_ShouldReturnScoredFinalKill()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+        Weapon finalLevelWeapon = Weapon.Knife;
+
+        killer.LevelUp(_maxLevel);
+        killer.LevelUp(_maxLevel);
+        killer.LevelUp(_maxLevel);
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, finalLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.ScoredFinalKill);
+        killer.WeaponLevel.Value.Should().Be(_maxLevel.Value);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
+    }
+
+    [Test]
+    public void ProcessKill_WhenVictimIsAtFirstLevelAndKilledWithKnife_ShouldReturnNone()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+        Weapon firstLevelWeapon = Weapon.Knife;
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, firstLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.None);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
+        victim.KillsTowardsNextLevel.Should().Be(0);
+    }
+
+    [Test]
+    public void ProcessKill_WhenVictimIsAboveFirstLevelAndKilledWithKnife_ShouldLevelDownVictim()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+        Weapon finalLevelWeapon = Weapon.Knife;
+        victim.LevelUp(_maxLevel);
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, finalLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.LeveledDown);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
+        victim.KillsTowardsNextLevel.Should().Be(0);
+    }
+
+    [Test]
+    public void ProcessKill_WhenPlayerAtFirstLevelKillsWithWeaponFromAnotherLevel_ShouldReturnNone()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+        Weapon weaponFromAnotherLevel = Weapon.M4;
+        killer.AddKillsTowardsNextLevel();
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, weaponFromAnotherLevel);
+
+        // Assert
+        result.Should().Be(GunGameResult.None);
+        killer.WeaponLevel.Should().Be(WeaponLevel.First);
+        killer.KillsTowardsNextLevel.Should().Be(1);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
+    }
+
+    [Test]
+    public void ProcessKill_WhenRequiredKillsHaveNotBeenReached_ShouldReturnNone()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+        Weapon firstLevelWeapon = Weapon.Colt45;
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, firstLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.None);
+        killer.WeaponLevel.Should().Be(WeaponLevel.First);
+        killer.KillsTowardsNextLevel.Should().Be(1);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
+    }
+
+    [Test]
+    public void ProcessKill_WhenRequiredKillsAreReached_ShouldReturnLeveledUp()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+        killer.AddKillsTowardsNextLevel();
+        Weapon firstLevelWeapon = Weapon.Colt45;
+        int expectedWeaponLevel = 2;
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, firstLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.LeveledUp);
+        killer.WeaponLevel.Value.Should().Be(expectedWeaponLevel);
+        killer.KillsTowardsNextLevel.Should().Be(0);
+        victim.WeaponLevel.Should().Be(WeaponLevel.First);
+    }
+
+    [Test]
+    public void ProcessKill_WhenPlayerReachesFinalLevel_ShouldReturnReachedFinalLevel()
+    {
+        // Arrange
+        var killer = new PlayerProgression();
+        var victim = new PlayerProgression();
+
+        killer.LevelUp(_maxLevel);
+        killer.LevelUp(_maxLevel);
+
+        killer.AddKillsTowardsNextLevel();
+        Weapon thirdLevelWeapon = Weapon.AK47;
+
+        // Act
+        GunGameResult result = _gunGame.ProcessKill(killer, victim, thirdLevelWeapon);
+
+        // Assert
+        result.Should().Be(GunGameResult.ReachedFinalLevel);
+        killer.WeaponLevel.Value.Should().Be(_maxLevel.Value);
+        killer.KillsTowardsNextLevel.Should().Be(0);
+    }
+}

--- a/tests/Application.Tests/GunGames/TestWeaponProgression.cs
+++ b/tests/Application.Tests/GunGames/TestWeaponProgression.cs
@@ -1,0 +1,17 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class TestWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.Classic;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.Colt45,
+            WeaponDefinitions.Shotgun,
+            WeaponDefinitions.AK47,
+            WeaponDefinitions.Knife
+        ]);
+    }
+}

--- a/tests/Application.Tests/GunGames/TestWeaponProgression.cs
+++ b/tests/Application.Tests/GunGames/TestWeaponProgression.cs
@@ -15,3 +15,19 @@ public class TestWeaponProgression : WeaponProgressionBase
         ]);
     }
 }
+
+public class NonKnifeFinalWeaponProgression : WeaponProgressionBase
+{
+    public override WeaponProgressionType Type => WeaponProgressionType.Classic;
+
+    protected override void Define(List<IWeapon> weapons)
+    {
+        weapons.AddRange(
+        [
+            WeaponDefinitions.Colt45,
+            WeaponDefinitions.MP5,
+            WeaponDefinitions.Knife,
+            WeaponDefinitions.Minigun
+        ]);
+    }
+}

--- a/tests/Application.Tests/GunGames/WeaponLevelTests.cs
+++ b/tests/Application.Tests/GunGames/WeaponLevelTests.cs
@@ -1,0 +1,136 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class WeaponLevelTests
+{
+    private readonly MaxWeaponLevel _maxLevel = new(4);
+
+    [Test]
+    public void Next_WhenWeaponLevelIsBelowMaxLevel_ShouldAdvanceToNextLevel()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+
+        // Act
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+
+        // Assert
+        secondLevel.Value.Should().Be(2);
+    }
+
+    [Test]
+    public void Next_WhenWeaponLevelIsAtMaxLevel_ShouldRemainAtMaxLevel()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+        WeaponLevel thirdLevel = secondLevel.Next(_maxLevel);
+        WeaponLevel finalLevel = thirdLevel.Next(_maxLevel);
+
+        // Act
+        WeaponLevel nextLevel = finalLevel.Next(_maxLevel);
+
+        // Assert
+        nextLevel.Value.Should().Be(_maxLevel.Value);
+    }
+
+    [Test]
+    public void Previous_WhenWeaponLevelIsAboveFirstLevel_ShouldMoveToPreviousLevel()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+        WeaponLevel thirdLevel = secondLevel.Next(_maxLevel);
+
+        // Act
+        WeaponLevel previousLevel = thirdLevel.Previous();
+
+        // Assert
+        previousLevel.Should().Be(secondLevel);
+    }
+
+    [Test]
+    public void Previous_WhenWeaponLevelIsAtFirstLevel_ShouldRemainAtFirstLevel()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+
+        // Act
+        WeaponLevel previousLevel = firstLevel.Previous();
+
+        // Assert
+        previousLevel.Should().Be(firstLevel);
+    }
+
+    [Test]
+    public void IsMax_WhenWeaponLevelIsMaxLevel_ShouldReturnTrue()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+        WeaponLevel thirdLevel = secondLevel.Next(_maxLevel);
+        WeaponLevel finalLevel = thirdLevel.Next(_maxLevel);
+
+        // Act
+        bool isMax = finalLevel.IsMax(_maxLevel);
+
+        // Assert
+        isMax.Should().BeTrue();
+    }
+
+    [Test]
+    public void IsMax_WhenWeaponLevelIsBelowMaxLevel_ShouldReturnFalse()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+
+        // Act
+        bool isMax = secondLevel.IsMax(_maxLevel);
+
+        // Assert
+        isMax.Should().BeFalse();
+    }
+
+    [Test]
+    public void ToString_ShouldReturnWeaponLevelValue()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+
+        // Act
+        string value = secondLevel.ToString();
+
+        // Assert
+        value.Should().Be("2");
+    }
+
+    [Test]
+    public void EqualityOperator_WhenWeaponLevelsAreEqual_ShouldReturnTrue()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel left = firstLevel.Next(_maxLevel);
+        WeaponLevel right = firstLevel.Next(_maxLevel);
+
+        // Act
+        bool areEqual = left == right;
+
+        // Assert
+        areEqual.Should().BeTrue();
+    }
+
+    [Test]
+    public void GreaterThanOperator_WhenLeftWeaponLevelIsGreater_ShouldReturnTrue()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_maxLevel);
+
+        // Act
+        bool isGreater = secondLevel > firstLevel;
+
+        // Assert
+        isGreater.Should().BeTrue();
+    }
+}

--- a/tests/Application.Tests/GunGames/WeaponProgressionBaseTests.cs
+++ b/tests/Application.Tests/GunGames/WeaponProgressionBaseTests.cs
@@ -1,0 +1,136 @@
+﻿namespace CTF.Application.Tests.GunGames;
+
+public class WeaponProgressionBaseTests
+{
+    private TestWeaponProgression _progression;
+
+    [SetUp]
+    public void Init()
+    {
+        _progression = new TestWeaponProgression();
+    }
+
+    [Test]
+    public void WeaponProgression_WhenNoWeaponsAreDefined_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+
+        // Act
+        Action act = () => _ = new EmptyWeaponProgression();
+
+        // Assert
+        act.Should()
+           .Throw<InvalidOperationException>()
+           .WithMessage("A weapon progression must define at least one weapon.");
+    }
+
+    [Test]
+    public void GetWeapon_WhenWeaponLevelIsFirst_ShouldReturnFirstWeapon()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+
+        // Act
+        IWeapon weapon = _progression.GetWeapon(firstLevel);
+
+        // Assert
+        weapon.Should().Be(WeaponDefinitions.Colt45);
+    }
+
+    [Test]
+    public void GetWeapon_WhenWeaponLevelIsSecond_ShouldReturnSecondWeapon()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_progression.MaxLevel);
+
+        // Act
+        IWeapon weapon = _progression.GetWeapon(secondLevel);
+
+        // Assert
+        weapon.Should().Be(WeaponDefinitions.Shotgun);
+    }
+
+    [Test]
+    public void GetWeapon_WhenWeaponLevelIsFinal_ShouldReturnFinalWeapon()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_progression.MaxLevel);
+        WeaponLevel thirdLevel = secondLevel.Next(_progression.MaxLevel);
+        WeaponLevel finalLevel = thirdLevel.Next(_progression.MaxLevel);
+
+        // Act
+        IWeapon weapon = _progression.GetWeapon(finalLevel);
+
+        // Assert
+        weapon.Should().Be(WeaponDefinitions.Knife);
+    }
+
+    [Test]
+    public void GetWeapon_WhenWeaponLevelIsBelowFirst_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        WeaponLevel weaponLevel = default;
+
+        // Act
+        Action act = () => _progression.GetWeapon(weaponLevel);
+
+        // Assert
+        act.Should()
+           .Throw<InvalidOperationException>()
+           .WithMessage("No weapon defined for level 0");
+
+    }
+
+    [Test]
+    public void MaxLevel_ShouldBeEqualToNumberOfWeapons()
+    {
+        // Arrange
+
+        // Act
+        MaxWeaponLevel maxLevel = _progression.MaxLevel;
+
+        // Assert
+        maxLevel.Value.Should().Be(4);
+    }
+
+    [Test]
+    public void IsFinalLevel_WhenWeaponLevelIsMaxLevel_ShouldReturnTrue()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_progression.MaxLevel);
+        WeaponLevel thirdLevel = secondLevel.Next(_progression.MaxLevel);
+        WeaponLevel finalLevel = thirdLevel.Next(_progression.MaxLevel);
+
+        // Act
+        bool isFinalLevel = _progression.IsFinalLevel(finalLevel);
+
+        // Assert
+        isFinalLevel.Should().BeTrue();
+    }
+
+    [Test]
+    public void IsFinalLevel_WhenWeaponLevelIsBelowMaxLevel_ShouldReturnFalse()
+    {
+        // Arrange
+        WeaponLevel firstLevel = WeaponLevel.First;
+        WeaponLevel secondLevel = firstLevel.Next(_progression.MaxLevel);
+
+        // Act
+        bool isFinalLevel = _progression.IsFinalLevel(secondLevel);
+
+        // Assert
+        isFinalLevel.Should().BeFalse();
+    }
+
+    private class EmptyWeaponProgression : WeaponProgressionBase
+    {
+        public override WeaponProgressionType Type => WeaponProgressionType.Classic;
+
+        protected override void Define(List<IWeapon> weapons)
+        {
+        }
+    }
+}

--- a/tests/Application.Tests/Usings.cs
+++ b/tests/Application.Tests/Usings.cs
@@ -16,4 +16,6 @@ global using CTF.Application.Teams;
 global using CTF.Application.Teams.Flags;
 global using CTF.Application.Maps;
 global using CTF.Application.Maps.Services;
+global using CTF.Application.GunGames;
+global using CTF.Application.GunGames.WeaponProgressions;
 global using CTF.Application.Tests.Fakes;


### PR DESCRIPTION
* Added behavior tests for GunGame progression rules.
* Added tests for `GunGame.ProcessKill`, `PlayerProgression` and `WeaponLevel`.
* Added tests for `WeaponProgressionBase` and GunGame value objects.
* Added `TestWeaponProgression` to support domain testing.