### PR TITLE
fix: handle explosive and fire-based kills in GunGame

### DIFF
--- a/src/Application/GunGames/GunGameSystem.cs
+++ b/src/Application/GunGames/GunGameSystem.cs
@@ -33,15 +33,21 @@ public class GunGameSystem(
     [Event]
     public void OnPlayerDeath(Player victim, Player killer, Weapon reason)
     {
-        if (!IsEnabled)
-            return;
-
-        if (killer is null)
+        if (!IsEnabled || killer is null)
             return;
 
         var killerProgression = killer.GetComponent<PlayerProgression>();
         var victimProgression = victim.GetComponent<PlayerProgression>();
         var gunGame = new GunGame(weaponProgression, gunGameSession.KillsRequiredPerLevel);
+
+        IWeapon expectedWeapon = weaponProgression.GetWeapon(killerProgression.WeaponLevel);
+
+        // open.mp reports explosive and fire-based kills using generic death reasons,
+        // without preserving the weapon that caused the kill. Since GunGame restricts
+        // players to a single expected weapon, these ambiguous reasons can be mapped
+        // back to the expected weapon before being processed by the domain.
+        if (reason is Weapon.Explosion or Weapon.FlameThrower)
+            reason = expectedWeapon.Id;
 
         GunGameResult result = gunGame.ProcessKill(killerProgression, victimProgression, reason);
         if (result == GunGameResult.None)


### PR DESCRIPTION
Fixed GunGame progression for explosive and fire-based weapons.

open.mp reports kills caused by explosions and fire using generic death reasons (Explosion and FlameThrower) instead of the weapon that actually caused the kill (e.g. Rocket Launcher, Grenade or Molotov). As a result, GunGame could not correctly validate kills performed with those weapons.

Since GunGame guarantees that players are restricted to a single expected weapon at each progression level, ambiguous death reasons are mapped back to the expected weapon before being processed by the GunGame domain.