### PR TITLE
feat: protect server owner from privileged player actions

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -196,6 +196,15 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You cannot perform this action on the server owner..
+        /// </summary>
+        internal static string CannotPerformActionOnServerOwner {
+            get {
+                return ResourceManager.GetString("CannotPerformActionOnServerOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Chat is currently disabled while you select your class. Please finish your selection before chatting!.
         /// </summary>
         internal static string ChatDisabled {

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -568,4 +568,7 @@ Capture the Flag is about to begin.</value>
   <data name="RankUpAwardSummary" xml:space="preserve">
     <value>+{Health} Health, +{Armour} Armour, +{Coins} Coins</value>
   </data>
+  <data name="CannotPerformActionOnServerOwner" xml:space="preserve">
+    <value>You cannot perform this action on the server owner.</value>
+  </data>
 </root>

--- a/src/Application/Players/Accounts/Roles/PlayerRoleSystem.cs
+++ b/src/Application/Players/Accounts/Roles/PlayerRoleSystem.cs
@@ -24,6 +24,12 @@ public class PlayerRoleSystem(
             return;
         }
 
+        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        {
+            currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
+            return;
+        }
+
         PlayerInfo targetPlayerInfo = targetPlayer.GetRequiredInfo();
         RoleId newRoleId = (RoleId)roleId;
         RoleId oldRoleId = targetPlayerInfo.RoleId;

--- a/src/Application/Players/GeneralCommands/AdminCommands.cs
+++ b/src/Application/Players/GeneralCommands/AdminCommands.cs
@@ -4,7 +4,8 @@ public class AdminCommands(
     IEntityManager entityManager,
     IServerService serverService,
     IWorldService worldService,
-    IDialogService dialogService) : ISystem
+    IDialogService dialogService,
+    ServerOwnerSettings serverOwnerSettings) : ISystem
 {
     [PlayerCommand("cmdsadmin")]
     [RequiresMinimumRole(RoleId.Admin)]
@@ -84,6 +85,12 @@ public class AdminCommands(
         if (currentPlayer == targetPlayer)
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.PlayerIsEqualsToTargetPlayer);
+            return;
+        }
+
+        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        {
+            currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;
         }
 

--- a/src/Application/Players/GeneralCommands/ModeratorCommands.cs
+++ b/src/Application/Players/GeneralCommands/ModeratorCommands.cs
@@ -1,6 +1,8 @@
 ﻿namespace CTF.Application.Players.GeneralCommands;
 
-public class ModeratorCommands(IWorldService worldService) : ISystem
+public class ModeratorCommands(
+    IWorldService worldService,
+    ServerOwnerSettings serverOwnerSettings) : ISystem
 {
     [PlayerCommand("cmdsmoderator")]
     [RequiresMinimumRole(RoleId.Moderator)]
@@ -31,6 +33,12 @@ public class ModeratorCommands(IWorldService worldService) : ISystem
         if (currentPlayer == targetPlayer)
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.PlayerIsEqualsToTargetPlayer);
+            return;
+        }
+
+        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        {
+            currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;
         }
 
@@ -94,6 +102,12 @@ public class ModeratorCommands(IWorldService worldService) : ISystem
         if (currentPlayer == targetPlayer)
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.PlayerIsEqualsToTargetPlayer);
+            return;
+        }
+
+        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        {
+            currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;
         }
 

--- a/src/Application/Players/PlayerExtensions.cs
+++ b/src/Application/Players/PlayerExtensions.cs
@@ -67,4 +67,22 @@ public static class PlayerExtensions
         player.Color = Team.None.ColorHex;
         return currentTeam;
     }
+
+    /// <summary>
+    /// Determines whether the specified player is the server owner.
+    /// </summary>
+    /// <param name="player">
+    /// The player to check.
+    /// </param>
+    /// <param name="ownerName">
+    /// The name configured as the server owner.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the player's name matches the configured
+    /// server owner name; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool IsServerOwner(this Player player, string ownerName)
+        => player.Name.Equals(
+            ownerName,
+            StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
Prevent privileged player actions from being executed against the server owner.

Added server owner validation to the following commands:
* /ban
* /warn
* /kick
* /setrole

This prevents administrators and moderators from accidentally or intentionally performing privileged actions on the configured server owner.