### PR TITLE
refactor(di): introduce helper methods for service registrations

### DIFF
--- a/src/Application/GunGames/ServiceCollectionExtensions.cs
+++ b/src/Application/GunGames/ServiceCollectionExtensions.cs
@@ -11,14 +11,14 @@ public static class GunGameExtensions
             .AddSingleton<IGunGameMode>(sp => sp.GetRequiredService<GunGameSystem>());
 
         services
-            .AddSingleton<WeaponProgressionBase, ClassicWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, HardcoreWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, PistolsWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, ReverseClassicWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, RiflesWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, ShotgunsWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, SmgsWeaponProgression>()
-            .AddSingleton<WeaponProgressionBase, PowerfulWeaponProgression>()
+            .AddWeaponProgression<ClassicWeaponProgression>()
+            .AddWeaponProgression<HardcoreWeaponProgression>()
+            .AddWeaponProgression<PistolsWeaponProgression>()
+            .AddWeaponProgression<ReverseClassicWeaponProgression>()
+            .AddWeaponProgression<RiflesWeaponProgression>()
+            .AddWeaponProgression<ShotgunsWeaponProgression>()
+            .AddWeaponProgression<SmgsWeaponProgression>()
+            .AddWeaponProgression<PowerfulWeaponProgression>()
             .AddSingleton<IDictionary<WeaponProgressionType, WeaponProgressionBase>>(sp =>
             {
                 var progressions = sp.GetRequiredService<IEnumerable<WeaponProgressionBase>>();
@@ -26,16 +26,30 @@ public static class GunGameExtensions
             });
 
         services
-            .AddSingleton<IGunGameResultHandler, PlayerLeveledDown>()
-            .AddSingleton<IGunGameResultHandler, PlayerLeveledUp>()
-            .AddSingleton<IGunGameResultHandler, PlayerReachedFinalLevel>()
-            .AddSingleton<IGunGameResultHandler, PlayerScoredFinalKill>()
+            .AddGunGameResultHandler<PlayerLeveledDown>()
+            .AddGunGameResultHandler<PlayerLeveledUp>()
+            .AddGunGameResultHandler<PlayerReachedFinalLevel>()
+            .AddGunGameResultHandler<PlayerScoredFinalKill>()
             .AddSingleton<IDictionary<GunGameResult, IGunGameResultHandler>>(sp =>
             {
                 var handlers = sp.GetRequiredService<IEnumerable<IGunGameResultHandler>>();
                 return handlers.ToDictionary(h => h.Result);
             });
 
+        return services;
+    }
+
+    private static IServiceCollection AddWeaponProgression<T>(this IServiceCollection services)
+        where T : WeaponProgressionBase
+    {
+        services.AddSingleton<WeaponProgressionBase, T>();
+        return services;
+    }
+
+    private static IServiceCollection AddGunGameResultHandler<T>(this IServiceCollection services)
+        where T : class, IGunGameResultHandler
+    {
+        services.AddSingleton<IGunGameResultHandler, T>();
         return services;
     }
 }

--- a/src/Application/Players/Chats/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Chats/ServiceCollectionExtensions.cs
@@ -5,16 +5,23 @@ public static class ChatServicesExtensions
     public static IServiceCollection AddChatServices(this IServiceCollection services)
     {
         services
-            .AddSingleton<IChatMessage, PrivateAdminChat>()
-            .AddSingleton<IChatMessage, PrivateModeratorChat>()
-            .AddSingleton<IChatMessage, PrivateTeamChat>()
-            .AddSingleton<IChatMessage, PrivateVipChat>()
+            .AddChatMessage<PrivateAdminChat>()
+            .AddChatMessage<PrivateModeratorChat>()
+            .AddChatMessage<PrivateTeamChat>()
+            .AddChatMessage<PrivateVipChat>()
             .AddSingleton<IDictionary<char, IChatMessage>>(sp =>
             {
                 var chats = sp.GetRequiredService<IEnumerable<IChatMessage>>();
                 return chats.ToDictionary(c => c.Id);
             });
 
+        return services;
+    }
+
+    private static IServiceCollection AddChatMessage<T>(this IServiceCollection services)
+        where T : class, IChatMessage
+    {
+        services.AddSingleton<IChatMessage, T>();
         return services;
     }
 }

--- a/src/Application/Players/Combos/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Combos/ServiceCollectionExtensions.cs
@@ -6,13 +6,20 @@ public static class ComboServicesExtensions
     {
         services
             .AddSingleton<ComboSettings>()
-            .AddSingleton<ICombo, FlamethrowerVitality>()
-            .AddSingleton<ICombo, GrenadesVitality>()
-            .AddSingleton<ICombo, MolotovVitality>()
-            .AddSingleton<ICombo, RocketLauncherVitality>()
-            .AddSingleton<ICombo, SatchelChargesVitality>()
-            .AddSingleton<ICombo, TearGasVitality>();
+            .AddCombo<FlamethrowerVitality>()
+            .AddCombo<GrenadesVitality>()
+            .AddCombo<MolotovVitality>()
+            .AddCombo<RocketLauncherVitality>()
+            .AddCombo<SatchelChargesVitality>()
+            .AddCombo<TearGasVitality>();
 
+        return services;
+    }
+
+    private static IServiceCollection AddCombo<T>(this IServiceCollection services)
+        where T : class, ICombo
+    {
+        services.AddSingleton<ICombo, T>();
         return services;
     }
 }

--- a/src/Application/Players/Weapons/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Weapons/ServiceCollectionExtensions.cs
@@ -5,13 +5,13 @@ public static class WeaponServicesExtensions
     public static IServiceCollection AddWeaponServices(this IServiceCollection services)
     {
         services
-            .AddSingleton<WeaponCatalogBase, RunWeaponCatalog>()
-            .AddSingleton<WeaponCatalogBase, WalkingWeaponCatalog>()
-            .AddSingleton<WeaponCatalogBase, MixedWeaponCatalog>()
-            .AddSingleton<WeaponCatalogBase, RifleOnlyWeaponCatalog>()
-            .AddSingleton<WeaponCatalogBase, WarWeaponCatalog>()
-            .AddSingleton<WeaponCatalogBase, HeavyWeaponCatalog>()
-            .AddSingleton<WeaponCatalogBase, MeleeWeaponCatalog>()
+            .AddWeaponCatalog<RunWeaponCatalog>()
+            .AddWeaponCatalog<WalkingWeaponCatalog>()
+            .AddWeaponCatalog<MixedWeaponCatalog>()
+            .AddWeaponCatalog<RifleOnlyWeaponCatalog>()
+            .AddWeaponCatalog<WarWeaponCatalog>()
+            .AddWeaponCatalog<HeavyWeaponCatalog>()
+            .AddWeaponCatalog<MeleeWeaponCatalog>()
             .AddSingleton<WeaponCatalog>()
             .AddSingleton<IDictionary<WeaponCatalogType, WeaponCatalogBase>>(sp =>
             {
@@ -19,6 +19,13 @@ public static class WeaponServicesExtensions
                 return catalogs.ToDictionary(w => w.Type);
             });
 
+        return services;
+    }
+
+    private static IServiceCollection AddWeaponCatalog<T>(this IServiceCollection services)
+        where T : WeaponCatalogBase
+    {
+        services.AddSingleton<WeaponCatalogBase, T>();
         return services;
     }
 }

--- a/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
@@ -5,12 +5,12 @@ public static class FlagServicesExtensions
     public static IServiceCollection AddFlagServices(this IServiceCollection services)
     {
         services
-            .AddSingleton<IFlagEvent, OnFlagAtBasePosition>()
-            .AddSingleton<IFlagEvent, OnFlagCaptured>()
-            .AddSingleton<IFlagEvent, OnFlagReturned>()
-            .AddSingleton<IFlagEvent, OnFlagDropped>()
-            .AddSingleton<IFlagEvent, OnFlagScore>()
-            .AddSingleton<IFlagEvent, OnFlagTaken>()
+            .AddFlagEvent<OnFlagAtBasePosition>()
+            .AddFlagEvent<OnFlagCaptured>()
+            .AddFlagEvent<OnFlagReturned>()
+            .AddFlagEvent<OnFlagDropped>()
+            .AddFlagEvent<OnFlagScore>()
+            .AddFlagEvent<OnFlagTaken>()
             .AddSingleton<IDictionary<FlagStatus, IFlagEvent>>(sp =>
             {
                 var flagEvents = sp.GetRequiredService<IEnumerable<IFlagEvent>>();
@@ -21,6 +21,13 @@ public static class FlagServicesExtensions
             .AddSingleton<FlagAutoReturnTimer>()
             .AddSingleton<FlagStateResetter>();
 
+        return services;
+    }
+
+    private static IServiceCollection AddFlagEvent<T>(this IServiceCollection services)
+        where T : class, IFlagEvent
+    {
+        services.AddSingleton<IFlagEvent, T>();
         return services;
     }
 }


### PR DESCRIPTION
Introduce dedicated helper methods to register module-specific services.

This change replaces repeated `AddSingleton<TService, TImplementation>()` calls with expressive methods such as:
* `AddWeaponCatalog<T>()`
* `AddChatMessage<T>()`
* `AddFlagEvent<T>()`
* `AddCombo<T>()`
* `AddWeaponProgression<T>()`
* `AddGunGameResultHandler<T>()`