### PR TITLE
refactor(di): replace service dictionaries with FrozenDictionary

### DIFF
--- a/src/Application/GunGames/GunGameSystem.cs
+++ b/src/Application/GunGames/GunGameSystem.cs
@@ -4,7 +4,7 @@ public class GunGameSystem(
     IEntityManager entityManager,
     IWorldService worldService,
     IDialogService dialogService,
-    IDictionary<GunGameResult, IGunGameResultHandler> handlers,
+    FrozenDictionary<GunGameResult, IGunGameResultHandler> handlers,
     WeaponProgression weaponProgression,
     GunGameSession gunGameSession,
     GunGameReward gunGameReward) : ISystem, IGunGameMode

--- a/src/Application/GunGames/ServiceCollectionExtensions.cs
+++ b/src/Application/GunGames/ServiceCollectionExtensions.cs
@@ -19,10 +19,10 @@ public static class GunGameExtensions
             .AddWeaponProgression<ShotgunsWeaponProgression>()
             .AddWeaponProgression<SmgsWeaponProgression>()
             .AddWeaponProgression<PowerfulWeaponProgression>()
-            .AddSingleton<IDictionary<WeaponProgressionType, WeaponProgressionBase>>(sp =>
+            .AddSingleton(sp =>
             {
                 var progressions = sp.GetRequiredService<IEnumerable<WeaponProgressionBase>>();
-                return progressions.ToDictionary(w => w.Type);
+                return progressions.ToFrozenDictionary(w => w.Type);
             });
 
         services
@@ -30,10 +30,10 @@ public static class GunGameExtensions
             .AddGunGameResultHandler<PlayerLeveledUp>()
             .AddGunGameResultHandler<PlayerReachedFinalLevel>()
             .AddGunGameResultHandler<PlayerScoredFinalKill>()
-            .AddSingleton<IDictionary<GunGameResult, IGunGameResultHandler>>(sp =>
+            .AddSingleton(sp =>
             {
                 var handlers = sp.GetRequiredService<IEnumerable<IGunGameResultHandler>>();
-                return handlers.ToDictionary(h => h.Result);
+                return handlers.ToFrozenDictionary(h => h.Result);
             });
 
         return services;

--- a/src/Application/GunGames/WeaponProgressions/WeaponProgression.cs
+++ b/src/Application/GunGames/WeaponProgressions/WeaponProgression.cs
@@ -9,7 +9,7 @@
 /// </remarks>
 public class WeaponProgression(
     GunGameSession gunGameSession,
-    IDictionary<WeaponProgressionType, WeaponProgressionBase> progressions)
+    FrozenDictionary<WeaponProgressionType, WeaponProgressionBase> progressions)
 {
     private WeaponProgressionBase Current
         => progressions[gunGameSession.WeaponProgressionType];

--- a/src/Application/Players/Chats/ChatSystem.cs
+++ b/src/Application/Players/Chats/ChatSystem.cs
@@ -1,6 +1,6 @@
 ﻿namespace CTF.Application.Players.Chats;
 
-public class ChatSystem(IDictionary<char, IChatMessage> chats) : ISystem
+public class ChatSystem(FrozenDictionary<char, IChatMessage> chats) : ISystem
 {
     /// <summary>
     /// This callback is called when a player sends a message in chat.

--- a/src/Application/Players/Chats/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Chats/ServiceCollectionExtensions.cs
@@ -9,10 +9,10 @@ public static class ChatServicesExtensions
             .AddChatMessage<PrivateModeratorChat>()
             .AddChatMessage<PrivateTeamChat>()
             .AddChatMessage<PrivateVipChat>()
-            .AddSingleton<IDictionary<char, IChatMessage>>(sp =>
+            .AddSingleton(sp =>
             {
                 var chats = sp.GetRequiredService<IEnumerable<IChatMessage>>();
-                return chats.ToDictionary(c => c.Id);
+                return chats.ToFrozenDictionary(c => c.Id);
             });
 
         return services;

--- a/src/Application/Players/Weapons/ServiceCollectionExtensions.cs
+++ b/src/Application/Players/Weapons/ServiceCollectionExtensions.cs
@@ -13,10 +13,10 @@ public static class WeaponServicesExtensions
             .AddWeaponCatalog<HeavyWeaponCatalog>()
             .AddWeaponCatalog<MeleeWeaponCatalog>()
             .AddSingleton<WeaponCatalog>()
-            .AddSingleton<IDictionary<WeaponCatalogType, WeaponCatalogBase>>(sp =>
+            .AddSingleton(sp =>
             {
                 var catalogs = sp.GetRequiredService<IEnumerable<WeaponCatalogBase>>();
-                return catalogs.ToDictionary(w => w.Type);
+                return catalogs.ToFrozenDictionary(w => w.Type);
             });
 
         return services;

--- a/src/Application/Players/Weapons/WeaponCatalog.cs
+++ b/src/Application/Players/Weapons/WeaponCatalog.cs
@@ -10,7 +10,7 @@
 /// </remarks>
 public class WeaponCatalog(
     WeaponCatalogSettings settings, 
-    IDictionary<WeaponCatalogType, WeaponCatalogBase> catalogs)
+    FrozenDictionary<WeaponCatalogType, WeaponCatalogBase> catalogs)
 {
     private WeaponCatalogBase Current => catalogs[settings.Type];
 

--- a/src/Application/Teams/Flags/FlagSystem.cs
+++ b/src/Application/Teams/Flags/FlagSystem.cs
@@ -2,7 +2,7 @@
 
 public class FlagSystem(
     IWorldService worldService,
-    IDictionary<FlagStatus, IFlagEvent> flagEvents,
+    FrozenDictionary<FlagStatus, IFlagEvent> flagEvents,
     TeamPickupService teamPickupService,
     FlagAutoReturnTimer flagAutoReturnTimer,
     PlayerStatsRenderer playerStatsRenderer) : ISystem

--- a/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/Flags/ServiceCollectionExtensions.cs
@@ -11,10 +11,10 @@ public static class FlagServicesExtensions
             .AddFlagEvent<OnFlagDropped>()
             .AddFlagEvent<OnFlagScore>()
             .AddFlagEvent<OnFlagTaken>()
-            .AddSingleton<IDictionary<FlagStatus, IFlagEvent>>(sp =>
+            .AddSingleton(sp =>
             {
                 var flagEvents = sp.GetRequiredService<IEnumerable<IFlagEvent>>();
-                return flagEvents.ToDictionary(f => f.FlagStatus);
+                return flagEvents.ToFrozenDictionary(f => f.FlagStatus);
             });
 
         services

--- a/src/Application/Usings.cs
+++ b/src/Application/Usings.cs
@@ -3,6 +3,7 @@ global using System.Numerics;
 global using System.Text;
 global using System.Collections;
 global using System.Globalization;
+global using System.Collections.Frozen;
 global using System.Text.RegularExpressions;
 global using SampSharp.Streamer.Entities;
 global using SampSharp.Entities;

--- a/tests/Application.Tests/GunGames/ProcessKillTests.cs
+++ b/tests/Application.Tests/GunGames/ProcessKillTests.cs
@@ -17,7 +17,7 @@ public class ProcessKillTests
         var progressions = new Dictionary<WeaponProgressionType, WeaponProgressionBase>
         {
             [WeaponProgressionType.Classic] = new TestWeaponProgression()
-        };
+        }.ToFrozenDictionary();
 
         var weaponProgression = new WeaponProgression(session, progressions);
         _gunGame = new GunGame(weaponProgression, session.KillsRequiredPerLevel);
@@ -173,7 +173,7 @@ public class ProcessKillTests
         var progressions = new Dictionary<WeaponProgressionType, WeaponProgressionBase>
         {
             [WeaponProgressionType.Classic] = new NonKnifeFinalWeaponProgression()
-        };
+        }.ToFrozenDictionary();
 
         var weaponProgression = new WeaponProgression(session, progressions);
         var gunGame = new GunGame(weaponProgression, session.KillsRequiredPerLevel);

--- a/tests/Application.Tests/Usings.cs
+++ b/tests/Application.Tests/Usings.cs
@@ -1,5 +1,6 @@
 ﻿global using System.Collections;
 global using System.Numerics;
+global using System.Collections.Frozen;
 global using NUnit.Framework;
 global using NSubstitute;
 global using FluentAssertions;


### PR DESCRIPTION
Replace mutable service dictionaries with FrozenDictionary for singleton registrations.

The registered dictionaries are created only once during the first resolution and remain alive for the lifetime of the application. Since they are never modified after construction, FrozenDictionary better represents their intended usage.

The primary motivation for this change is to express immutability through the type system, making the dependency contract clearer and preventing accidental modifications.

Any performance improvement is expected to be negligible due to the small number of entries and is considered a secondary benefit.