### PR TITLE
fix(commands): reduce self-kill exploit at low health

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -682,6 +682,15 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You don&apos;t have enough health to perform this action..
+        /// </summary>
+        internal static string NotEnoughHealth {
+            get {
+                return ResourceManager.GetString("NotEnoughHealth", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no VIP players connected at the moment.
         /// </summary>
         internal static string NoVIPsConnected {
@@ -903,15 +912,6 @@ namespace CTF.Application {
         internal static string PlayerNotFound {
             get {
                 return ResourceManager.GetString("PlayerNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You don&apos;t have enough health.
-        /// </summary>
-        internal static string PlayerWithInsufficientHealth {
-            get {
-                return ResourceManager.GetString("PlayerWithInsufficientHealth", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -682,7 +682,7 @@ namespace CTF.Application {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You don&apos;t have enough health to perform this action..
+        ///   Looks up a localized string similar to You don&apos;t have enough health to perform this action.
         /// </summary>
         internal static string NotEnoughHealth {
             get {

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -388,7 +388,7 @@
     <value>Player '{Name}' is not found</value>
   </data>
   <data name="NotEnoughHealth" xml:space="preserve">
-    <value>You don't have enough health to perform this action.</value>
+    <value>You don't have enough health to perform this action</value>
   </data>
   <data name="PrivateMessagesBlocked" xml:space="preserve">
     <value>That player has private messages blocked</value>

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -387,8 +387,8 @@
   <data name="PlayerNotFound" xml:space="preserve">
     <value>Player '{Name}' is not found</value>
   </data>
-  <data name="PlayerWithInsufficientHealth" xml:space="preserve">
-    <value>You don't have enough health</value>
+  <data name="NotEnoughHealth" xml:space="preserve">
+    <value>You don't have enough health to perform this action.</value>
   </data>
   <data name="PrivateMessagesBlocked" xml:space="preserve">
     <value>That player has private messages blocked</value>

--- a/src/Application/Players/GeneralCommands/BasicCommands.cs
+++ b/src/Application/Players/GeneralCommands/BasicCommands.cs
@@ -4,6 +4,9 @@ public class BasicCommands(
     IEntityManager entityManager,
     IDialogService dialogService) : ISystem
 {
+    private const float MinimumHealthToUseKillCommand = 15f;
+    private const float MinimumHealthToUseSpectatorCommand = 85f;
+
     [PlayerCommand("cmds")]
     public async Task ShowFirstCommandsPage(Player player)
     {
@@ -94,6 +97,12 @@ public class BasicCommands(
             return;
         }
 
+        if (player.Health < MinimumHealthToUseKillCommand)
+        {
+            player.SendClientMessage(Color.Red, Messages.NotEnoughHealth);
+            return;
+        }
+
         player.Health = 0;
     }
 
@@ -159,9 +168,9 @@ public class BasicCommands(
             return;
         }
 
-        if (currentPlayer.Health < 85)
+        if (currentPlayer.Health < MinimumHealthToUseSpectatorCommand)
         {
-            currentPlayer.SendClientMessage(Color.Red, Messages.PlayerWithInsufficientHealth);
+            currentPlayer.SendClientMessage(Color.Red, Messages.NotEnoughHealth);
             return;
         }
 

--- a/src/Application/Teams/ClassSelection/ClassSelectionSystem.cs
+++ b/src/Application/Teams/ClassSelection/ClassSelectionSystem.cs
@@ -6,6 +6,8 @@ public class ClassSelectionSystem(
     TeamTextDrawRenderer teamTextDrawRenderer,
     ClassSelectionSettings classSelectionSettings) : ISystem
 {
+    private const float MinimumHealthToUseClassSelectionCommand = 85f;
+
     [Event]
     public void OnGameModeInit(IServerService serverService)
     {
@@ -97,9 +99,9 @@ public class ClassSelectionSystem(
             return;
         }
 
-        if (player.Health < 85)
+        if (player.Health < MinimumHealthToUseClassSelectionCommand)
         {
-            player.SendClientMessage(Color.Red, Messages.PlayerWithInsufficientHealth);
+            player.SendClientMessage(Color.Red, Messages.NotEnoughHealth);
             return;
         }
 


### PR DESCRIPTION
In GunGame, players could use **/kill** just before being killed with a knife, preventing the attacker from triggering the intended level-down mechanic. A minimum health requirement reduces this gameplay exploit.

Also replace hardcoded health thresholds in player commands with named constants to improve readability and maintainability.