### PR TITLE
refactor: decouple match result announcement

### DIFF
--- a/src/Application/Maps/Rotation/MapRotationService.cs
+++ b/src/Application/Maps/Rotation/MapRotationService.cs
@@ -63,8 +63,6 @@ public class MapRotationService(
     {
         _isMapLoading = true;
         LoadingMapEvent?.Invoke();
-        var matchResult = MatchResult.Create(Team.Alpha, Team.Beta);
-        worldService.SendClientMessage(Color.Yellow, matchResult.Announcement);
         mapObjects.Unload();
 
         IEnumerable<Player> players = MatchPlayers.GetAll();

--- a/src/Application/Teams/Matches/MatchResult.cs
+++ b/src/Application/Teams/Matches/MatchResult.cs
@@ -3,29 +3,19 @@
 public class MatchResult
 {
     public Team Winner { get; }
-    public string Announcement { get; }
     public bool IsTie => Winner == Team.None;
 
-    private MatchResult(Team winner, string announcement)
-    {
-        Winner = winner;
-        Announcement = announcement;
-    }
+    private MatchResult(Team winner)
+        => Winner = winner;
 
     public static MatchResult Create(Team firstTeam, Team secondTeam)
     {
         if (firstTeam.IsWinner())
-            return new MatchResult(
-                firstTeam, 
-                Smart.Format(Messages.TeamIsWinner, new { firstTeam.Name })
-            );
+            return new MatchResult(firstTeam);
 
         if (secondTeam.IsWinner())
-            return new MatchResult(
-                secondTeam, 
-                Smart.Format(Messages.TeamIsWinner, new { secondTeam.Name })
-            );
+            return new MatchResult(secondTeam);
 
-        return new MatchResult(Team.None, Messages.TiedTeams);
+        return new MatchResult(Team.None);
     }
 }

--- a/src/Application/Teams/Matches/MatchResultAnnouncer.cs
+++ b/src/Application/Teams/Matches/MatchResultAnnouncer.cs
@@ -1,0 +1,17 @@
+﻿namespace CTF.Application.Teams.Matches;
+
+public class MatchResultAnnouncer(IWorldService worldService)
+{
+    public void Announce()
+    {
+        MatchResult result = MatchResult.Create(Team.Alpha, Team.Beta);
+
+        string resultMessage = result.IsTie ? 
+            Messages.TiedTeams : 
+            Smart.Format(
+                Messages.TeamIsWinner,
+                new { result.Winner.Name });
+
+        worldService.SendClientMessage(Color.Yellow, resultMessage);
+    }
+}

--- a/src/Application/Teams/ServiceCollectionExtensions.cs
+++ b/src/Application/Teams/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ public static class TeamServicesExtensions
             .AddSingleton<TeamIconService>()
             .AddSingleton<TeamTextDrawRenderer>()
             .AddSingleton<TeamBalancer>()
+            .AddSingleton<MatchResultAnnouncer>()
             .AddSingleton<ClassSelectionTextDrawRenderer>()
             .AddFlagServices();
 

--- a/src/Host/Extensions/HostEcsBuilderExtensions.cs
+++ b/src/Host/Extensions/HostEcsBuilderExtensions.cs
@@ -15,8 +15,10 @@ public static class HostEcsBuilderExtensions
         var mapRotationService = builder.Services.GetRequiredService<MapRotationService>();
         var rocketLauncherSystem = builder.Services.GetRequiredService<RocketLauncherSystem>();
         var gunGameSystem = builder.Services.GetRequiredService<GunGameSystem>();
+        var matchResultAnnouncer = builder.Services.GetRequiredService<MatchResultAnnouncer>();
         mapRotationService.LoadingMapEvent += rocketLauncherSystem.OnLoadingMap;
         mapRotationService.LoadingMapEvent += gunGameSystem.OnLoadingMap;
+        mapRotationService.LoadingMapEvent += matchResultAnnouncer.Announce;
         return builder;
     }
 

--- a/src/Host/Usings.cs
+++ b/src/Host/Usings.cs
@@ -26,6 +26,7 @@ global using CTF.Application.Teams.ClassSelection;
 global using CTF.Application.Teams.Flags;
 global using CTF.Application.Teams.Flags.Carriers;
 global using CTF.Application.Teams.Flags.AutoReturn;
+global using CTF.Application.Teams.Matches;
 global using CTF.Application.Maps;
 global using CTF.Application.Maps.Rotation;
 global using CTF.Application.GunGames;

--- a/tests/Application.Tests/Teams/MatchResultTests.cs
+++ b/tests/Application.Tests/Teams/MatchResultTests.cs
@@ -21,7 +21,6 @@ public class MatchResultTests
         // Assert
         result.Winner.Should().Be(Team.Alpha);
         result.IsTie.Should().BeFalse();
-        result.Announcement.Should().Be(Messages.AlphaIsWinner);
     }
 
     [Test]
@@ -36,7 +35,6 @@ public class MatchResultTests
         // Assert
         result.Winner.Should().Be(Team.Beta);
         result.IsTie.Should().BeFalse();
-        result.Announcement.Should().Be(Messages.BetaIsWinner);
     }
 
     [Test]
@@ -52,6 +50,5 @@ public class MatchResultTests
         // Assert
         result.Winner.Should().Be(Team.None);
         result.IsTie.Should().BeTrue();
-        result.Announcement.Should().Be(Messages.TiedTeams);
     }
 }


### PR DESCRIPTION
## Motivation

`MapRotationService` was responsible for announcing match results in addition to coordinating map rotation.
This caused the map rotation logic to depend on `MatchResult` and presentation-specific message formatting. 

The `MatchResult` domain model also contained an `Announcement` property solely for this presentation concern.
The match result should represent the outcome of the match without knowing how that result is presented to players.

The match result is announced when a new map begins loading, but `MatchResultAnnouncer` exposes `Announce()` to describe its actual responsibility rather than the event that triggers it. The map loading event is only the mechanism used to invoke the announcement.

## Changes

- Remove `Announcement` property from `MatchResult`.
- Update `MatchResultTests` to remove presentation-specific assertions.
- Remove the `MatchResult` dependency from `MapRotationService`.
- Introduce `MatchResultAnnouncer` to handle match result presentation.
- Expose `MatchResultAnnouncer.Announce()` as its public operation.
- Subscribe `MatchResultAnnouncer.Announce()` to the `MapRotationService.LoadingMapEvent` event.

## Benefits

- `MapRotationService` is no longer coupled to match result presentation.
- `MatchResult` now represents only the outcome of the match.
- Match result presentation is encapsulated in `MatchResultAnnouncer`.
- Presentation-specific messages are kept outside the domain model.