### PR TITLE
feat: add match result GameText summary

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -1213,6 +1213,15 @@ namespace CTF.Application {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ~w~Tie!.
+        /// </summary>
+        internal static string Tie {
+            get {
+                return ResourceManager.GetString("Tie", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to It&apos;s a tie! Both teams couldn&apos;t beat each other this time.
         /// </summary>
         internal static string TiedTeams {
@@ -1399,6 +1408,15 @@ namespace CTF.Application {
         internal static string Welcome3 {
             get {
                 return ResourceManager.GetString("Welcome3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {GameTextStyle} Winner: {TeamName}.
+        /// </summary>
+        internal static string Winner {
+            get {
+                return ResourceManager.GetString("Winner", resourceCulture);
             }
         }
         

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -571,4 +571,10 @@ Capture the Flag is about to begin.</value>
   <data name="CannotPerformActionOnServerOwner" xml:space="preserve">
     <value>You cannot perform this action on the server owner.</value>
   </data>
+  <data name="Winner" xml:space="preserve">
+    <value>{GameTextStyle} Winner: {TeamName}</value>
+  </data>
+  <data name="Tie" xml:space="preserve">
+    <value>~w~Tie!</value>
+  </data>
 </root>

--- a/src/Application/Teams/Matches/MatchResultAnnouncer.cs
+++ b/src/Application/Teams/Matches/MatchResultAnnouncer.cs
@@ -12,6 +12,17 @@ public class MatchResultAnnouncer(IWorldService worldService)
                 Messages.TeamIsWinner,
                 new { result.Winner.Name });
 
+        string resultSummary = result.IsTie ?
+            Messages.Tie :
+            Smart.Format(
+                Messages.Winner,
+                new
+                {
+                    GameTextStyle = result.Winner.GameText,
+                    TeamName = result.Winner.Name
+                });
+
         worldService.SendClientMessage(Color.Yellow, resultMessage);
+        worldService.GameText(resultSummary, TimeSpan.FromSeconds(4), GameTextStyle.Style3);
     }
 }


### PR DESCRIPTION
## Motivation

The match result announcement currently provides a detailed message to players through the client chat.

A concise visual summary makes the result easier to notice when a match ends, especially during map rotation.

## Changes

- Add `Messages.Tie` for tie summaries.
- Add `Messages.Winner` as a template for winner summaries.
- Generate a concise match result summary for `GameText`.
- Use the winning team's `GameText` style and name in the winner summary.
- Display the summary for 4 seconds when the match result is announced.

## Examples

```text
Tie!
Winner: Alpha