### PR TITLE
refactor: clarify GameText color terminology

### DIFF
--- a/src/Application/Messages.Designer.cs
+++ b/src/Application/Messages.Designer.cs
@@ -709,7 +709,7 @@ namespace CTF.Application {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ~n~~n~~n~{GameText}Defend this flag from enemy capture!.
+        ///   Looks up a localized string similar to ~n~~n~~n~{GameTextColor}Defend this flag from enemy capture!.
         /// </summary>
         internal static string OnFlagAtBasePosition {
             get {
@@ -1412,7 +1412,7 @@ namespace CTF.Application {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {GameTextStyle} Winner: {TeamName}.
+        ///   Looks up a localized string similar to {GameTextColor} Winner: {TeamName}.
         /// </summary>
         internal static string Winner {
             get {

--- a/src/Application/Messages.resx
+++ b/src/Application/Messages.resx
@@ -319,7 +319,7 @@
     <value>You already have that skin</value>
   </data>
   <data name="OnFlagAtBasePosition" xml:space="preserve">
-    <value>~n~~n~~n~{GameText}Defend this flag from enemy capture!</value>
+    <value>~n~~n~~n~{GameTextColor}Defend this flag from enemy capture!</value>
   </data>
   <data name="OnFlagCaptured" xml:space="preserve">
     <value>{PlayerName} has captured the {TeamName} team's {ColorName} flag! Keep an eye on the score!</value>
@@ -572,7 +572,7 @@ Capture the Flag is about to begin.</value>
     <value>You cannot perform this action on the server owner.</value>
   </data>
   <data name="Winner" xml:space="preserve">
-    <value>{GameTextStyle} Winner: {TeamName}</value>
+    <value>{GameTextColor} Winner: {TeamName}</value>
   </data>
   <data name="Tie" xml:space="preserve">
     <value>~w~Tie!</value>

--- a/src/Application/Teams/Flags/AutoReturn/FlagAutoReturnTimer.cs
+++ b/src/Application/Teams/Flags/AutoReturn/FlagAutoReturnTimer.cs
@@ -26,7 +26,7 @@ public class FlagAutoReturnTimer(
                 team.ColorName
             });
             worldService.SendClientMessage(team.ColorHex, message);
-            worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+            worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
             Stop(team);
         }
 

--- a/src/Application/Teams/Flags/Carriers/FlagCarrierPauseSystem.cs
+++ b/src/Application/Teams/Flags/Carriers/FlagCarrierPauseSystem.cs
@@ -67,7 +67,7 @@ public class FlagCarrierPauseSystem(
                 Seconds = flagCarrierSettings.PauseTime
             });
             worldService.SendClientMessage(rivalTeam.ColorHex, message);
-            worldService.GameText($"~n~~n~~n~{rivalTeam.GameText}{rivalTeam.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+            worldService.GameText($"~n~~n~~n~{rivalTeam.GameTextColor}{rivalTeam.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
         }
     }
 

--- a/src/Application/Teams/Flags/Events/OnFlagAtBasePosition.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagAtBasePosition.cs
@@ -9,7 +9,7 @@ public class OnFlagAtBasePosition : IFlagEvent
 
     public void Handle(Team team, Player player)
     {
-        var text = Smart.Format(Messages.OnFlagAtBasePosition, new { team.GameText });
+        var text = Smart.Format(Messages.OnFlagAtBasePosition, new { team.GameTextColor });
         player.GameText(text, TimeSpan.FromSeconds(5), GameTextStyle.Style3);
     }
 }

--- a/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagCaptured.cs
@@ -27,7 +27,7 @@ public class OnFlagCaptured(
             team.ColorName
         });
         worldService.SendClientMessage(team.ColorHex, message);
-        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag captured!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+        worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} flag captured!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.AddCoins(EarnedCoins);

--- a/src/Application/Teams/Flags/Events/OnFlagDropped.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagDropped.cs
@@ -24,7 +24,7 @@ public class OnFlagDropped(
             team.ColorName
         });
         worldService.SendClientMessage(team.ColorHex, message);
-        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag dropped!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+        worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} flag dropped!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.AddDroppedFlags();

--- a/src/Application/Teams/Flags/Events/OnFlagReturned.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagReturned.cs
@@ -28,7 +28,7 @@ public class OnFlagReturned(
             team.ColorName
         });
         worldService.SendClientMessage(team.ColorHex, message);
-        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+        worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.AddCoins(EarnedCoins);

--- a/src/Application/Teams/Flags/Events/OnFlagScore.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagScore.cs
@@ -32,7 +32,7 @@ public class OnFlagScore(
             team.RivalTeam.ColorName
         });
         worldService.SendClientMessage(team.ColorHex, message);
-        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} team scores!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+        worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} team scores!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
 
         PlayerInfo playerInfo = player.GetRequiredInfo();
         playerInfo.StatsPerRound.AddCoins(CarrierEarnedCoins);

--- a/src/Application/Teams/Flags/Events/OnFlagTaken.cs
+++ b/src/Application/Teams/Flags/Events/OnFlagTaken.cs
@@ -23,7 +23,7 @@ public class OnFlagTaken(
             team.ColorName
         });
         worldService.SendClientMessage(team.ColorHex, message);
-        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag taken!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+        worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} flag taken!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
         if (flagCarrierSettings.ShowOnRadarMap)
         {
             player.ShowOnRadarMap();

--- a/src/Application/Teams/Flags/FlagSystem.cs
+++ b/src/Application/Teams/Flags/FlagSystem.cs
@@ -113,7 +113,7 @@ public class FlagSystem(
         teamPickupService.DestroyExteriorMarker(team);
         team.Sounds.PlayFlagReturnedSound();
         flagAutoReturnTimer.Stop(team);
-        worldService.GameText($"~n~~n~~n~{team.GameText}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
+        worldService.GameText($"~n~~n~~n~{team.GameTextColor}{team.ColorName} flag returned!", TimeSpan.FromSeconds(5), GameTextStyle.Style3);
         worldService.SendClientMessage(Color.Yellow, message);
     }
 }

--- a/src/Application/Teams/Matches/MatchResultAnnouncer.cs
+++ b/src/Application/Teams/Matches/MatchResultAnnouncer.cs
@@ -18,7 +18,7 @@ public class MatchResultAnnouncer(IWorldService worldService)
                 Messages.Winner,
                 new
                 {
-                    GameTextStyle = result.Winner.GameText,
+                    result.Winner.GameTextColor,
                     TeamName = result.Winner.Name
                 });
 

--- a/src/Application/Teams/Team.cs
+++ b/src/Application/Teams/Team.cs
@@ -10,36 +10,36 @@ public class Team
     {
         Alpha = new Team
         {
-            Id         = TeamId.Alpha,
-            SkinId     = SkinTeamId.Alpha,
-            Name       = "Alpha",
-            ColorName  = "red",
-            GameText   = "~r~",
-            ColorHex   = new Color(255, 32, 64, 00),
-            Sounds     = TeamSounds.Alpha,
-            Flag       = new Flag
+            Id            = TeamId.Alpha,
+            SkinId        = SkinTeamId.Alpha,
+            Name          = "Alpha",
+            ColorName     = "red",
+            GameTextColor = "~r~",
+            ColorHex      = new Color(255, 32, 64, 00),
+            Sounds        = TeamSounds.Alpha,
+            Flag          = new Flag
             {
-                Model  = FlagModel.Red,
-                Icon   = FlagIcon.Red,
-                Name   = "Red",
-                ColorHex = Color.Red
+                Model     = FlagModel.Red,
+                Icon      = FlagIcon.Red,
+                Name      = "Red",
+                ColorHex  = Color.Red
             }
         };
 
         Beta = new Team
         {
-            Id         = TeamId.Beta,
-            SkinId     = SkinTeamId.Beta,
-            Name       = "Beta",
-            ColorName  = "blue",
-            GameText   = "~b~",
-            ColorHex   = new Color(0, 136, 255, 00),
-            Sounds     = TeamSounds.Beta,
-            Flag       = new Flag
+            Id            = TeamId.Beta,
+            SkinId        = SkinTeamId.Beta,
+            Name          = "Beta",
+            ColorName     = "blue",
+            GameTextColor = "~b~",
+            ColorHex      = new Color(0, 136, 255, 00),
+            Sounds        = TeamSounds.Beta,
+            Flag          = new Flag
             {
-                Model  = FlagModel.Blue,
-                Icon   = FlagIcon.Blue,
-                Name   = "Blue",
+                Model     = FlagModel.Blue,
+                Icon      = FlagIcon.Blue,
+                Name      = "Blue",
                 ColorHex = Color.Blue
             }
         };
@@ -48,19 +48,19 @@ public class Team
         Beta.RivalTeam  = Alpha;
         None = new NoTeam
         {
-            Id         = TeamId.NoTeam,
-            SkinId     = SkinTeamId.NoTeam,
-            Name       = "NoTeam",
-            ColorName  = "white",
-            GameText   = "~w~",
-            ColorHex   = new Color(255, 255, 255, 00),
-            Sounds     = TeamSounds.None,
-            Flag       = new Flag
+            Id            = TeamId.NoTeam,
+            SkinId        = SkinTeamId.NoTeam,
+            Name          = "NoTeam",
+            ColorName     = "white",
+            GameTextColor = "~w~",
+            ColorHex      = new Color(255, 255, 255, 00),
+            Sounds        = TeamSounds.None,
+            Flag          = new Flag
             {
-                Model  = FlagModel.None,
-                Icon   = FlagIcon.White,
-                Name   = "NoTeam",
-                ColorHex = Color.White
+                Model     = FlagModel.None,
+                Icon      = FlagIcon.White,
+                Name      = "NoTeam",
+                ColorHex  = Color.White
             },
         };
         None.RivalTeam = None;
@@ -70,7 +70,17 @@ public class Team
     public SkinTeamId SkinId { get; private set; }
     public string Name { get; private set; }
     public string ColorName { get; private set; }
-    public string GameText { get; private set; }
+
+    /// <summary>
+    /// Gets the text color used by open.mp <c>GameText</c>.
+    /// </summary>
+    /// <remarks>
+    /// See the <see href="https://open.mp/docs/scripting/resources/gametextstyles#text-colors">
+    /// open.mp GameText text colors documentation
+    /// </see>.
+    /// </remarks>
+    public string GameTextColor { get; private set; }
+
     public Color ColorHex { get; private set; }
     public TeamSounds Sounds { get; private set; }
     public Flag Flag { get; private set; }


### PR DESCRIPTION
## Motivation

The `Team.GameText` property did not clearly communicate what the value represents. The property stores an [open.mp GameText text color](https://open.mp/es/docs/scripting/resources/gametextstyles#text-colors), such as `~r~` or `~b~`, rather than a GameText style.

This ambiguity was also reflected in the message resources, where `GameText` and `GameTextStyle` were used inconsistently for the same color-related concept.

The terminology should clearly distinguish the GameText text color from the GameText style used when displaying a [GameText](https://open.mp/es/docs/scripting/functions/GameTextForPlayer) message.

## Changes

- Rename `Team.GameText` to `Team.GameTextColor`.
- Add XML documentation referencing the open.mp GameText text colors documentation.
- Rename the corresponding `GameText` message resource to `GameTextColor`.
- Rename the `GameTextStyle` message resource to `GameTextColor`.
- Update all usages to use the new `GameTextColor` terminology.