### PR TITLE
refactor: reduce match result GameText duration

### DIFF
--- a/src/Application/Teams/Matches/MatchResultAnnouncer.cs
+++ b/src/Application/Teams/Matches/MatchResultAnnouncer.cs
@@ -23,6 +23,6 @@ public class MatchResultAnnouncer(IWorldService worldService)
                 });
 
         worldService.SendClientMessage(Color.Yellow, resultMessage);
-        worldService.GameText(resultSummary, TimeSpan.FromSeconds(4), GameTextStyle.Style3);
+        worldService.GameText(resultSummary, TimeSpan.FromSeconds(2), GameTextStyle.Style3);
     }
 }


### PR DESCRIPTION
Reduce the match result GameText duration from 4 seconds to 2 seconds to make the summary less intrusive during map rotation.