### PR TITLE
refactor: simplify GetAvailabilityMessage signature

### DIFF
--- a/src/Application/Teams/Team.cs
+++ b/src/Application/Teams/Team.cs
@@ -98,13 +98,10 @@ public class Team
         Flag.Reset();
     }
 
-    public virtual string GetAvailabilityMessage(bool entireMessage = true)
-    {
-        if (IsFull())
-            return entireMessage ? $"~y~{Name}~n~~r~ not available" : "not available";
-
-        return entireMessage ? $"~y~{Name}~n~~r~ available" : "available";
-    }
+    public virtual string GetAvailabilityMessage()
+        => IsFull() ? 
+        $"~y~{Name}~n~~r~ not available" : 
+        $"~y~{Name}~n~~r~ available";
 
     /// <summary>
     /// Handles a player's interaction with the team's flag.
@@ -149,7 +146,7 @@ public class Team
     private class NoTeam : Team
     {
         public NoTeam() { }
-        public override string GetAvailabilityMessage(bool entireMessage = true) => string.Empty;
+        public override string GetAvailabilityMessage() => string.Empty;
         public override FlagStatus HandleFlagInteraction(Player flagPicker) => FlagStatus.BasePosition;
         public override string GetMembersAsText() => string.Empty;
         public override string GetScoreAsText() => string.Empty;

--- a/tests/Application.Tests/Teams/TeamTests.cs
+++ b/tests/Application.Tests/Teams/TeamTests.cs
@@ -106,12 +106,11 @@ public class TeamTests
         actual.Should().BeFalse();
     }
 
-    [TestCase("~y~Alpha~n~~r~ not available", true)]
-    [TestCase("not available", false)]
-    public void GetAvailabilityMessage_WhenTeamIsFull_ShouldReturnUnavailableMessage(
-        string expectedMessage, bool entireMessage)
+    [Test]
+    public void GetAvailabilityMessage_WhenTeamIsFull_ShouldReturnUnavailableMessage()
     {
         // Arrange
+        var expectedMessage = "~y~Alpha~n~~r~ not available";
         Team alphaTeam = Team.Alpha;
         Team betaTeam = Team.Beta;
         alphaTeam.Members.Add(new FakePlayer(id: 1, name: "Bob"));
@@ -119,25 +118,24 @@ public class TeamTests
         betaTeam.Members.Add(new FakePlayer(id: 3, name: "Dave"));
 
         // Act
-        string actual = alphaTeam.GetAvailabilityMessage(entireMessage);
+        string actual = alphaTeam.GetAvailabilityMessage();
 
         // Assert
         actual.Should().Be(expectedMessage);
     }
 
-    [TestCase("~y~Alpha~n~~r~ available", true)]
-    [TestCase("available", false)]
-    public void GetAvailabilityMessage_WhenTeamIsNotFull_ShouldReturnAvailableMessage(
-        string expectedMessage, bool entireMessage)
+    [Test]
+    public void GetAvailabilityMessage_WhenTeamIsNotFull_ShouldReturnAvailableMessage()
     {
         // Arrange
+        var expectedMessage = "~y~Alpha~n~~r~ available";
         Team alphaTeam = Team.Alpha;
         Team betaTeam = Team.Beta;
         alphaTeam.Members.Add(new FakePlayer(id: 1, name: "Bob"));
         betaTeam.Members.Add(new FakePlayer(id: 3, name: "Dave"));
 
         // Act
-        string actual = alphaTeam.GetAvailabilityMessage(entireMessage);
+        string actual = alphaTeam.GetAvailabilityMessage();
 
         // Assert
         actual.Should().Be(expectedMessage);


### PR DESCRIPTION
Remove the unused entireMessage parameter from Team.GetAvailabilityMessage and update its tests accordingly.