### PR TITLE
refactor: improve IsServerOwner API

### DIFF
--- a/src/Application/Players/Accounts/Roles/PlayerRoleSystem.cs
+++ b/src/Application/Players/Accounts/Roles/PlayerRoleSystem.cs
@@ -24,7 +24,7 @@ public class PlayerRoleSystem(
             return;
         }
 
-        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        if (targetPlayer.IsServerOwner())
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;

--- a/src/Application/Players/GeneralCommands/AdminCommands.cs
+++ b/src/Application/Players/GeneralCommands/AdminCommands.cs
@@ -4,8 +4,7 @@ public class AdminCommands(
     IEntityManager entityManager,
     IServerService serverService,
     IWorldService worldService,
-    IDialogService dialogService,
-    ServerOwnerSettings serverOwnerSettings) : ISystem
+    IDialogService dialogService) : ISystem
 {
     [PlayerCommand("cmdsadmin")]
     [RequiresMinimumRole(RoleId.Admin)]
@@ -88,7 +87,7 @@ public class AdminCommands(
             return;
         }
 
-        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        if (targetPlayer.IsServerOwner())
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;

--- a/src/Application/Players/GeneralCommands/ModeratorCommands.cs
+++ b/src/Application/Players/GeneralCommands/ModeratorCommands.cs
@@ -1,8 +1,6 @@
 ﻿namespace CTF.Application.Players.GeneralCommands;
 
-public class ModeratorCommands(
-    IWorldService worldService,
-    ServerOwnerSettings serverOwnerSettings) : ISystem
+public class ModeratorCommands(IWorldService worldService) : ISystem
 {
     [PlayerCommand("cmdsmoderator")]
     [RequiresMinimumRole(RoleId.Moderator)]
@@ -36,7 +34,7 @@ public class ModeratorCommands(
             return;
         }
 
-        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        if (targetPlayer.IsServerOwner())
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;
@@ -105,7 +103,7 @@ public class ModeratorCommands(
             return;
         }
 
-        if (targetPlayer.IsServerOwner(serverOwnerSettings.Name))
+        if (targetPlayer.IsServerOwner())
         {
             currentPlayer.SendClientMessage(Color.Red, Messages.CannotPerformActionOnServerOwner);
             return;

--- a/src/Application/Players/PlayerExtensions.cs
+++ b/src/Application/Players/PlayerExtensions.cs
@@ -74,15 +74,16 @@ public static class PlayerExtensions
     /// <param name="player">
     /// The player to check.
     /// </param>
-    /// <param name="ownerName">
-    /// The name configured as the server owner.
-    /// </param>
     /// <returns>
-    /// <see langword="true"/> if the player's name matches the configured
-    /// server owner name; otherwise, <see langword="false"/>.
+    /// <see langword="true"/> if the player is the server owner;
+    /// otherwise, <see langword="false"/>.
     /// </returns>
-    public static bool IsServerOwner(this Player player, string ownerName)
-        => player.Name.Equals(
+    public static bool IsServerOwner(this Player player)
+    {
+        var envReader = new EnvReader();
+        var ownerName = envReader["ServerOwner__Name"];
+        return player.Name.Equals(
             ownerName,
             StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
Remove the `ownerName` parameter from `Player.IsServerOwner` and resolve the configured server owner internally.

This keeps the owner configuration detail encapsulated by the API, allowing consumers to query whether a player is the server owner without providing configuration data.

The direct dependency on [EnvReader](https://devd4v3.github.io/dotenv.core/api/DotEnv.Core.EnvReader.html) is intentional because server owner configuration is always provided through environment variables.